### PR TITLE
fix: remove swww deprecation warning

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -200,7 +200,7 @@ class App(Gtk.Window):
             # Check available monitors:
             monitor_names = ["All"]
             try:
-                subprocess.Popen(["swww", "init"])
+                subprocess.Popen(["swww-daemon"])
                 query_output = str(subprocess.check_output(["swww", "query"], encoding='utf-8'))
                 monitors = query_output.split("\n")
                 for monitor in monitors[:-1]:

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -42,7 +42,7 @@ def change_wallpaper(image_path, cf, monitor, txt):
                     time.sleep(0.005)
                 except Exception as e:
                     print(f"{txt.err_kill} {e}")
-            subprocess.Popen(["swww", "init"])
+            subprocess.Popen(["swww-daemon"])
             command = ["swww", "img", image_path]
             command.extend(["--resize", fill])
             command.extend(["--fill-color", cf.color])


### PR DESCRIPTION
The usage of swww init instead of swww-daemon was causing a deprecation warning to appear "DEPRECATION WARNING: `swww init` IS DEPRECATED. Call `swww-daemon` directly instead".

`swww init` was depricated in version 0.9.0 of swww but `swww-daemon` was added back in version 0.7.0.

This fixes issue #39