### PR TITLE
enhancement: Add hyprpaper backend support

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -84,6 +84,21 @@ def change_wallpaper(image_path, cf, monitor, txt):
             subprocess.Popen(["setwallpaper", "--mode", fill, image_path])
             print(f"{txt.msg_setwith} {cf.backend}")
 
+        # hyprpaper backend:
+        elif cf.backend == "hyprpaper":
+            try:
+                subprocess.Popen(["hyprpaper"])
+                time.sleep(0.01)
+            except Exception as e:
+                print(f"{txt.err_kill} {e}")
+            preload_command = ["hyprctl", "hyprpaper", "preload", image_path]
+            if monitor == "All":
+                monitor = ""
+            wallpaper_command = ["hyprctl", "hyprpaper", "wallpaper", f"{monitor},{image_path}"]
+            subprocess.Popen(preload_command)
+            subprocess.Popen(wallpaper_command)
+            
+
         elif cf.backend == "none":
             pass
 

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -1,4 +1,4 @@
-BACKEND_OPTIONS = ["none", "swaybg", "swww", "feh", "wallutils"]
+BACKEND_OPTIONS = ["none", "swaybg", "swww", "feh", "wallutils", "hyprpaper"]
 FILL_OPTIONS = ["fill", "stretch", "fit", "center", "tile"]
 SORT_OPTIONS = ["name", "namerev", "date", "daterev"]
 SORT_DISPLAYS = {
@@ -12,6 +12,7 @@ IMAGE_EXTENSIONS = {
         BACKEND_OPTIONS[1]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff'],
         BACKEND_OPTIONS[2]: ['.gif', '.jpg', '.jpeg', '.png', '.bmp', '.pnm', '.tiff'],
         BACKEND_OPTIONS[3]: ['.gif', '.jpg', '.jpeg', '.png'],
+        BACKEND_OPTIONS[5]: ['.jpg', '.jpeg', '.png', '.webp'],
         }
 
 SWWW_TRANSITION_TYPES = ["any", "none", "simple", "fade", "wipe",  "left", "right", "top",


### PR DESCRIPTION
I added `hyprpaper` support using `hyprrctl`. I tested it with `--restore` flag and it restores the wallpapers properly. The `monitor` variable in `changer.py`  was locally changed to be an empty string if it was set to `All` so that `hyprpaper` would set it to all monitors correctly.

This fixes issue #7 .