### PR TITLE
fix: hyprpaper first launch not setting wallpaper correctly

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -84,8 +84,11 @@ def change_wallpaper(image_path, cf, monitor, txt):
 
         # hyprpaper backend:
         elif cf.backend == "hyprpaper":
-            subprocess.Popen(["hyprpaper"])
-            time.sleep(0.01)
+            try:
+                str(subprocess.check_output(["pgrep", "hyprpaper"], encoding='utf-8'))
+            except Exception:
+                subprocess.Popen(["hyprpaper"])
+                time.sleep(1)
             preload_command = ["hyprctl", "hyprpaper", "preload", image_path]
             if monitor == "All":
                 monitor = ""


### PR DESCRIPTION
I noticed a bug where there was not enough of a delay when changing wallpapers for the first time when `hyprpaper` was not already running that caused the wallpapers to be preloaded and set when the `hyprpaper` daemon was not yet loaded. I fixed this by checking if the `hyprpaper` process is already running and if not  launch `hyprpaper` and put a 1 second delay to ensure that the wallpaper is set correctly.

This fixes an bug introduced in #45 