### PR TITLE
fix: Hyprpaper would unload wallpaper before being applied.

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -97,10 +97,8 @@ def change_wallpaper(image_path, cf, monitor, txt):
                 monitor = ""
             wallpaper_command = ["hyprctl", "hyprpaper", "wallpaper", f"{monitor},{image_path}"]
             unload_command = ["hyprctl", "hyprpaper", "unload", "all"]
-            time.sleep(0.1)
             subprocess.Popen(unload_command)
             subprocess.Popen(preload_command)
-            time.sleep(0.1)
             subprocess.Popen(wallpaper_command)
 
         elif cf.backend == "none":

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -97,11 +97,11 @@ def change_wallpaper(image_path, cf, monitor, txt):
                 monitor = ""
             wallpaper_command = ["hyprctl", "hyprpaper", "wallpaper", f"{monitor},{image_path}"]
             unload_command = ["hyprctl", "hyprpaper", "unload", "all"]
+            time.sleep(0.1)
+            subprocess.Popen(unload_command)
             subprocess.Popen(preload_command)
             time.sleep(0.1)
             subprocess.Popen(wallpaper_command)
-            time.sleep(0.1)
-            subprocess.Popen(unload_command)
 
         elif cf.backend == "none":
             pass


### PR DESCRIPTION
I fixed a bug where `hyprpaper` would unload wallpapers after being applied. In the majority of cases, the wallpaper would apply correctly in spite of them being unloaded from memory. However, larger wallpapers would be unloaded before being applied to the screen. The unload command worked as intended after the fix, it would drastically reduce the memory consumption of `hyprpaper` when viewing wallpapers in `waypaper` and effectively cap memory consumption instead of constantly growing as was happening before. 