### PR TITLE
fix: Consistantly set wallpaper using hyprpaper backend

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -119,13 +119,14 @@ def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|Eng
             wallpaper_command = ["hyprctl", "hyprpaper", "wallpaper", f"{monitor},{image_path}"]
             unload_command = ["hyprctl", "hyprpaper", "unload", "all"]
             result: str = ""
-            while result != "ok":
+            retry_counter: int = 0
+            while result != "ok" and retry_counter < 10:
                 try:
                     result = subprocess.check_output(unload_command, encoding="utf-8").strip()
                     result = subprocess.check_output(preload_command, encoding="utf-8").strip()
                     result = subprocess.check_output(wallpaper_command, encoding="utf-8").strip()
                 except Exception:
-                    continue
+                    retry_counter += 1
 
         elif cf.backend == "none":
             pass

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from waypaper.config import Config
 from waypaper.translations import Chinese, English, French, German, Polish, Russian
+import sys
 
 
 def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|English|French|German|Polish|Russian):
@@ -117,9 +118,14 @@ def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|Eng
                 monitor = ""
             wallpaper_command = ["hyprctl", "hyprpaper", "wallpaper", f"{monitor},{image_path}"]
             unload_command = ["hyprctl", "hyprpaper", "unload", "all"]
-            subprocess.Popen(unload_command)
-            subprocess.Popen(preload_command)
-            subprocess.Popen(wallpaper_command)
+            result: str = ""
+            while result != "ok":
+                try:
+                    result = subprocess.check_output(unload_command, encoding="utf-8").strip()
+                    result = subprocess.check_output(preload_command, encoding="utf-8").strip()
+                    result = subprocess.check_output(wallpaper_command, encoding="utf-8").strip()
+                except Exception:
+                    continue
 
         elif cf.backend == "none":
             pass


### PR DESCRIPTION
As mentioned in issue #7 , the wallpapers would sometimes not be preloaded before being set by hyprpaper. This PR fixes that by serializing the shell commends using the check_output function and it also retries up to 10 times to set the wallpaper in the off chance that it somehow fails to set the wallpaper (although since it is serialized it should never happen).