### PR TITLE
Add listing of monitors and wallpapers through the command line option --list

### DIFF
--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 import time
+import json
 
 from waypaper.aboutdata import AboutData
 from waypaper.app import App
@@ -41,6 +42,7 @@ parser.add_argument("--restore", help=txt.msg_arg_rest, action="store_true")
 parser.add_argument("--random", help=txt.msg_arg_rand, action="store_true")
 parser.add_argument("--fill", help=txt.msg_arg_fill, choices=FILL_OPTIONS)
 parser.add_argument("--backend", help=txt.msg_arg_back, choices=BACKEND_OPTIONS)
+parser.add_argument("--export", help=txt.msg_arg_export, action='store_true')
 args = parser.parse_args()
 
 
@@ -68,6 +70,10 @@ def run():
     # Print the version and quit:
     if args.version:
         print(f"{about.applicationName()} v.{about.applicationVersion()}")
+        sys.exit(0)
+    
+    if args.export:
+        print(json.dumps(Config))
         sys.exit(0)
 
     # Start GUI:

--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -42,7 +42,7 @@ parser.add_argument("--restore", help=txt.msg_arg_rest, action="store_true")
 parser.add_argument("--random", help=txt.msg_arg_rand, action="store_true")
 parser.add_argument("--fill", help=txt.msg_arg_fill, choices=FILL_OPTIONS)
 parser.add_argument("--backend", help=txt.msg_arg_back, choices=BACKEND_OPTIONS)
-parser.add_argument("--export", help=txt.msg_arg_export, action='store_true')
+parser.add_argument("--list", help=txt.msg_arg_list, action='store_true')
 args = parser.parse_args()
 
 
@@ -72,8 +72,10 @@ def run():
         print(f"{about.applicationName()} v.{about.applicationVersion()}")
         sys.exit(0)
     
-    if args.export:
-        print(json.dumps(Config))
+    if args.list:
+        # Get the wallpapers and monitors and create a list of dictionaries
+        wallpapers_and_monitors = list(map(lambda x: {"monitor": x[0], "wallpaper": x[1]} ,zip(cf.monitors,cf.wallpapers_str.split(','))))
+        print(json.dumps(wallpapers_and_monitors))
         sys.exit(0)
 
     # Start GUI:

--- a/waypaper/translations.py
+++ b/waypaper/translations.py
@@ -11,6 +11,7 @@ class English:
         self.msg_arg_rest = "restore last wallpaper"
         self.msg_arg_back = "specify which backend to use to set wallpaper"
         self.msg_arg_rand = "set a random wallpaper"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "Selected image path:"
         self.msg_select = "Select"
@@ -60,6 +61,7 @@ class German:
         self.msg_arg_rest = "stellt das zuletzt verwendete Hintergrundbild wieder her"
         self.msg_arg_back = "legt das Backend fest, welches zum Setzen des Hintergrundbildes verwendet werden soll"
         self.msg_arg_rand = "wählt ein zufälliges Hintergrundbild aus"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "Pfad zum ausgewählten Bild:"
         self.msg_select = "Auswählen"
@@ -109,6 +111,7 @@ class French:
         self.msg_arg_rest = "restaurer le dernier papier peint"
         self.msg_arg_back = "spécifier quel backend utiliser pour définir le papier peint"
         self.msg_arg_rand = "définir un papier peint aléatoire"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "Chemin de l'image sélectionnée :"
         self.msg_select = "Sélectionner"
@@ -158,6 +161,7 @@ class Polish:
         self.msg_arg_rest = "przywróć ostatnią tapetę"
         self.msg_arg_back = "określ, który backend użyć do ustawienia tapety"
         self.msg_arg_rand = "ustaw losową tapetę"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "Wybrana ścieżka obrazu:"
         self.msg_select = "Wybierz"
@@ -207,6 +211,7 @@ class Russian:
         self.msg_arg_rest = "восстановить последние обои"
         self.msg_arg_back = "указать бэкенд для установки обоев"
         self.msg_arg_rand = "установить случайные обои"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "Выбранный путь к изображению:"
         self.msg_select = "Выбрать"
@@ -256,6 +261,7 @@ class Chinese:
         self.msg_arg_rest = "恢复上个壁纸"
         self.msg_arg_back = "指定使用哪个后端来设置壁纸"
         self.msg_arg_rand = "设置随机壁纸"
+        self.msg_arg_export = "export to standard output the config file"
 
         self.msg_path = "选择的图像路径："
         self.msg_select = "选择"

--- a/waypaper/translations.py
+++ b/waypaper/translations.py
@@ -11,7 +11,7 @@ class English:
         self.msg_arg_rest = "restore last wallpaper"
         self.msg_arg_back = "specify which backend to use to set wallpaper"
         self.msg_arg_rand = "set a random wallpaper"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "Selected image path:"
         self.msg_select = "Select"
@@ -61,7 +61,7 @@ class German:
         self.msg_arg_rest = "stellt das zuletzt verwendete Hintergrundbild wieder her"
         self.msg_arg_back = "legt das Backend fest, welches zum Setzen des Hintergrundbildes verwendet werden soll"
         self.msg_arg_rand = "wählt ein zufälliges Hintergrundbild aus"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "Pfad zum ausgewählten Bild:"
         self.msg_select = "Auswählen"
@@ -111,7 +111,7 @@ class French:
         self.msg_arg_rest = "restaurer le dernier papier peint"
         self.msg_arg_back = "spécifier quel backend utiliser pour définir le papier peint"
         self.msg_arg_rand = "définir un papier peint aléatoire"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "Chemin de l'image sélectionnée :"
         self.msg_select = "Sélectionner"
@@ -161,7 +161,7 @@ class Polish:
         self.msg_arg_rest = "przywróć ostatnią tapetę"
         self.msg_arg_back = "określ, który backend użyć do ustawienia tapety"
         self.msg_arg_rand = "ustaw losową tapetę"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "Wybrana ścieżka obrazu:"
         self.msg_select = "Wybierz"
@@ -211,7 +211,7 @@ class Russian:
         self.msg_arg_rest = "восстановить последние обои"
         self.msg_arg_back = "указать бэкенд для установки обоев"
         self.msg_arg_rand = "установить случайные обои"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "Выбранный путь к изображению:"
         self.msg_select = "Выбрать"
@@ -261,7 +261,7 @@ class Chinese:
         self.msg_arg_rest = "恢复上个壁纸"
         self.msg_arg_back = "指定使用哪个后端来设置壁纸"
         self.msg_arg_rand = "设置随机壁纸"
-        self.msg_arg_export = "export to standard output the config file"
+        self.msg_arg_list = "list wallpapers in json to standard out"
 
         self.msg_path = "选择的图像路径："
         self.msg_select = "选择"


### PR DESCRIPTION
This PR addresses the feature request in issue #55. It adds the command line option `--list` where the currently set wallpapers and their corresponding monitor in the form of a `JSON` string. The help text has been added to all of the languages in `translations.py` but are not translated in anything that is not English.