### PR TITLE
Quit the Appication with ESC

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -512,7 +512,7 @@ class App(Gtk.Window):
 
     def on_key_pressed(self, widget, event) -> None:
         """Process various key binding"""
-        if event.keyval == Gdk.KEY_q:
+        if (event.keyval == Gdk.KEY_q) or (event.keyval == Gdk.KEY_Escape):
             Gtk.main_quit()
 
         elif event.keyval == Gdk.KEY_r:


### PR DESCRIPTION
Add the `ESC` key as a quit action additionally to the `q` option. 
Probably more common for non-vim users