### PR TITLE
Have --restore argument actually restore the saved config

### DIFF
--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -51,9 +51,6 @@ args = parser.parse_args()
 def run():
     """Read user arguments and either run GUI app or just reset the wallpaper"""
 
-    if args.restore:
-        cf.read()
-        
     cf.read_parameters_from_user_arguments(args)
 
     # Set the wallpaper and quit:

--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -51,6 +51,9 @@ args = parser.parse_args()
 def run():
     """Read user arguments and either run GUI app or just reset the wallpaper"""
 
+    if args.restore:
+        cf.read()
+        
     cf.read_parameters_from_user_arguments(args)
 
     # Set the wallpaper and quit:

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -426,7 +426,7 @@ class App(Gtk.Window):
 
     def on_fill_option_changed(self, combo) -> None:
         """Save fill parameter when it was changed"""
-        self.cf.fill_option = combo.get_active_text()
+        self.cf.fill_option = combo.get_active_text().lower()
 
 
     def on_monitor_option_changed(self, combo) -> None:
@@ -468,7 +468,7 @@ class App(Gtk.Window):
         self.selected_index = self.image_paths.index(path)
         self.load_image_grid()
         print(self.txt.msg_path, self.cf.selected_wallpaper)
-        self.cf.fill_option = self.fill_option_combo.get_active_text() or self.cf.fill_option
+        self.cf.fill_option = self.fill_option_combo.get_active_text().lower() or self.cf.fill_option
         change_wallpaper(self.cf.selected_wallpaper, self.cf, self.cf.selected_monitor, self.txt)
         self.cf.save()
 
@@ -495,7 +495,7 @@ class App(Gtk.Window):
         if self.cf.selected_wallpaper is None:
             return
         print(self.txt.msg_path, self.cf.selected_wallpaper)
-        self.cf.fill_option = self.fill_option_combo.get_active_text() or self.cf.fill_option
+        self.cf.fill_option = self.fill_option_combo.get_active_text().lower() or self.cf.fill_option
         change_wallpaper(self.cf.selected_wallpaper, self.cf, self.cf.selected_monitor, self.txt)
         self.cf.save()
 
@@ -569,7 +569,7 @@ class App(Gtk.Window):
             self.cf.selected_wallpaper = wallpaper_path
             print(self.txt.msg_path, self.cf.selected_wallpaper)
             self.cf.backend = self.backend_option_combo.get_active_text()
-            self.cf.fill_option = self.fill_option_combo.get_active_text() or self.cf.fill_option
+            self.cf.fill_option = self.fill_option_combo.get_active_text().lower() or self.cf.fill_option
             change_wallpaper(self.cf.selected_wallpaper, self.cf, self.cf.selected_monitor, self.txt)
             self.cf.save()
 


### PR DESCRIPTION
I was annoyed when `waypaper --restore` only restored the image but not the settings used to display the image stored in `config.ini`, so I decided to fix that. That probably fits better with the expectations of what `--restore` is supposed to do.