### PR TITLE
Remove mixed use of Path/strings for file/folder locations from config

### DIFF
--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -60,9 +60,11 @@ def run():
         for wallpaper, monitor in zip(cf.wallpapers, cf.monitors):
 
             if args.random:
-                wallpaper = get_random_file(cf.backend, cf.image_folder, cf.include_subfolders, cf.show_hidden)
-                cf.selected_wallpaper = str(wallpaper)
-                cf.save()
+                wallpaper_str = get_random_file(cf.backend, str(cf.image_folder), cf.include_subfolders, cf.show_hidden)
+                if wallpaper_str:
+                    cf.select_wallpaper(wallpaper_str)
+                    cf.save()
+                    wallpaper = pathlib.Path(wallpaper_str)
 
             if wallpaper is None:
                 continue
@@ -85,7 +87,7 @@ def run():
 
     # Output wallpapers and monitors in json format:
     if args.list:
-        wallpapers_and_monitors = list(map(lambda x: {"monitor": x[0], "wallpaper": x[1]}, zip(cf.monitors,cf.wallpapers_str.split(','))))
+        wallpapers_and_monitors = list(map(lambda x: {"monitor": x[0], "wallpaper": str(x[1])}, zip(cf.monitors,cf.wallpapers)))
         print(json.dumps(wallpapers_and_monitors))
         sys.exit(0)
 

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -5,10 +5,11 @@ import time
 from waypaper.config import Config
 from waypaper.common import get_monitor_names_hyprctl
 from waypaper.translations import Chinese, English, French, German, Polish, Russian
+from pathlib import Path
 import re
 
 
-def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|English|French|German|Polish|Russian):
+def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|English|French|German|Polish|Russian):
     """Run system commands to change the wallpaper depending on the backend"""
 
     try:
@@ -27,7 +28,7 @@ def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|Eng
             command = ["swaybg"]
             # if monitor != "All":
                 # command.extend(["-o", monitor])
-            command.extend(["-i", image_path])
+            command.extend(["-i", str(image_path)])
             command.extend(["-m", fill, "-c", cf.color])
             subprocess.Popen(command)
             print(f"{txt.msg_setwith} {cf.backend}")
@@ -90,7 +91,7 @@ def change_wallpaper(image_path: str, cf: Config, monitor: str, txt: Chinese|Eng
                     }
             fill = fill_types[cf.fill_option.lower()]
             command = ["feh", fill, "--image-bg", cf.color]
-            command.extend([image_path])
+            command.extend([str(image_path)])
             subprocess.Popen(command)
             print(f"{txt.msg_setwith} {cf.backend}")
 

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -10,7 +10,7 @@ from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS
 from typing import List
 
 
-def has_image_extension(file_path: str, backend: str) -> List[str]:
+def has_image_extension(file_path: str, backend: str) -> bool:
     """Check if the file has image extension"""
     image_extensions = IMAGE_EXTENSIONS[backend]
     ext = os.path.splitext(file_path)[1].lower()
@@ -22,7 +22,7 @@ def get_image_paths(backend: str,
                     include_subfolders: bool = False,
                     include_hidden: bool = False,
                     only_gifs: bool = False,
-                    depth: bool = False):
+                    depth: int = 1):
     """Get a list of file paths depending on the filters that were requested"""
     image_paths = []
     for root, directories, files in os.walk(root_folder):
@@ -58,7 +58,7 @@ def get_image_paths(backend: str,
 def get_random_file(backend: str,
                     folder: str,
                     include_subfolders: bool,
-                    include_hidden: bool = False):
+                    include_hidden: bool = False) -> str | None:
     """Pick a random file from the folder"""
     try:
         image_paths = get_image_paths(backend,
@@ -105,7 +105,7 @@ def get_monitor_names_swww() -> List[str]:
         for monitor in monitors[:-1]:
             connected_monitors.append(monitor.split(':')[0])
     except Exception as e:
-        print(f"{self.txt.err_disp} {e}")
+        print(f"Exception: {e}")
 
     return connected_monitors
 
@@ -124,7 +124,7 @@ def get_monitor_names_hyprctl() -> List[str]:
         for line in query_output:
             connected_monitors.append(line.split(' ')[1])
     except Exception as e:
-        print(f"{self.txt.err_disp} {e}")
+        print(f"Exception: {e}")
 
     return connected_monitors
 

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -3,8 +3,7 @@
 import configparser
 from argparse import Namespace
 import pathlib
-import os
-from sys import exit
+from typing import List
 from platformdirs import user_config_path, user_pictures_path, user_cache_path
 
 from waypaper.aboutdata import AboutData
@@ -15,10 +14,11 @@ from waypaper.common import check_installed_backends
 class Config:
     """User configuration loaded from the config.ini file"""
     def __init__(self):
+        # All paths (folders or wallpapers) are Path objects
         self.home_path = pathlib.Path.home()
         self.image_folder = user_pictures_path()
         self.installed_backends = check_installed_backends()
-        self.selected_wallpaper = ""
+        self.selected_wallpaper = None
         self.selected_monitor = "All"
         self.fill_option = FILL_OPTIONS[0]
         self.sort_option = SORT_OPTIONS[0]
@@ -49,12 +49,21 @@ class Config:
         self.read()
         self.check_validity()
 
-    def shorten_path(self, path: str) -> str:
+    def select_wallpaper(self, path_str: str) -> None:
+        self.selected_wallpaper = pathlib.Path(path_str)
+
+    def shorten_path(self, path: pathlib.Path) -> str:
         """Replace home part of paths with tilde"""
-        if str(path).startswith(str(self.home_path)):
+        if path.is_relative_to(self.home_path):
             return str(path).replace(str(self.home_path), "~", 1)
-        else:
+        elif path:
             return str(path)
+        else:
+            return ''
+
+    def shortened_paths(self, paths: List[pathlib.Path]) -> str:
+        """Prepare a list of paths to be serialized as a comma separated string"""
+        return ','.join(self.shorten_path(p) for p in paths)
 
     def read(self) -> None:
         """Load data from the config.ini or use default if it does not exists"""
@@ -62,8 +71,8 @@ class Config:
         config.read(self.config_file, 'utf-8')
 
         # Read parameters:
-        self.image_folder = config.get("Settings", "folder", fallback=self.image_folder)
-        self.image_folder = pathlib.Path(self.image_folder).expanduser()
+        image_folder_str = config.get("Settings", "folder", fallback=self.image_folder)
+        self.image_folder = pathlib.Path(image_folder_str).expanduser()
         self.fill_option = config.get("Settings", "fill", fallback=self.fill_option)
         self.sort_option = config.get("Settings", "sort", fallback=self.sort_option)
         self.backend = config.get("Settings", "backend", fallback=self.backend)
@@ -78,21 +87,21 @@ class Config:
         self.include_subfolders = config.getboolean("Settings", "subfolders", fallback=self.include_subfolders)
         self.show_hidden = config.getboolean("Settings", "show_hidden", fallback=self.show_hidden)
         self.show_gifs_only = config.getboolean("Settings", "show_gifs_only", fallback=self.show_gifs_only)
-        self.monitors_str = config.get("Settings", "monitors", fallback=self.selected_monitor, raw=True)
-        self.wallpapers_str = config.get("Settings", "wallpaper", fallback="", raw=True)
-        self.number_of_columns = config.get("Settings", "number_of_columns", fallback=self.number_of_columns)
+        monitors_str = config.get("Settings", "monitors", fallback=self.selected_monitor, raw=True)
+        wallpapers_str = config.get("Settings", "wallpaper", fallback="", raw=True)
 
         # Check the validity of the number of columns:
         try:
+            self.number_of_columns = config.getint("Settings", "number_of_columns", fallback=self.number_of_columns)
             self.number_of_columns = int(self.number_of_columns) if int(self.number_of_columns) > 0 else 3
         except Exception:
             self.number_of_columns = 3
 
         # Convert strings to lists:
-        if self.monitors_str is not None:
-            self.monitors = [str(monitor) for monitor in self.monitors_str.split(",")]
-        if self.wallpapers_str is not None:
-            self.wallpapers = [pathlib.Path(paper).expanduser() for paper in self.wallpapers_str.split(",")]
+        if monitors_str:
+            self.monitors = [str(monitor) for monitor in monitors_str.split(",")]
+        if wallpapers_str:
+            self.wallpapers = [pathlib.Path(paper).expanduser() for paper in wallpapers_str.split(",")]
 
     def check_validity(self) -> None:
         """Check if the config parameters are valid and correct them if needed"""
@@ -116,17 +125,17 @@ class Config:
 
     def attribute_selected_wallpaper(self) -> None:
         """If only certain monitor was affected, change only its wallpaper"""
-        if self.selected_wallpaper == "":
+        if not self.selected_wallpaper:
             return
         if self.selected_monitor == "All":
             self.monitors = [self.selected_monitor]
-            self.wallpapers = [self.shorten_path(self.selected_wallpaper)]
+            self.wallpapers = [self.selected_wallpaper]
         elif self.selected_monitor in self.monitors:
             index = self.monitors.index(self.selected_monitor)
-            self.wallpapers[index] = self.shorten_path(self.selected_wallpaper)
+            self.wallpapers[index] = self.selected_wallpaper
         else:
             self.monitors.append(self.selected_monitor)
-            self.wallpapers.append(self.shorten_path(self.selected_wallpaper))
+            self.wallpapers.append(self.selected_wallpaper)
 
     def save(self) -> None:
         """Update the parameters and save them to the configuration file"""
@@ -140,7 +149,7 @@ class Config:
             config.add_section("Settings")
         config.set("Settings", "language", self.lang)
         config.set("Settings", "folder", self.shorten_path(self.image_folder))
-        config.set("Settings", "wallpaper", ",".join(self.wallpapers))
+        config.set("Settings", "wallpaper", self.shortened_paths(self.wallpapers))
         config.set("Settings", "backend", self.backend)
         config.set("Settings", "monitors", ",".join(self.monitors))
         config.set("Settings", "fill", self.fill_option)
@@ -158,7 +167,6 @@ class Config:
         config.set("Settings", "swww_transition_fps", str(self.swww_transition_fps))
         with open(self.config_file, "w") as configfile:
             config.write(configfile)
-
 
     def read_parameters_from_user_arguments(self, args: Namespace) -> None:
         """


### PR DESCRIPTION
This fixes the issue #73 

## Description

Config class currently doesn't encapsulate the properties such as `selected_wallpaper` and `wallpapers` properly. External calls change the state of the property and they do so inconsistently. Some will set them to plain strings others to `pathlib.Path` objects. The issue is that `Path` cannot be serialized automatically as a string, which makes saving config fragile and it breaks.

This change enforces a few things:
1. Config will always serialize to plain types (string/int) and deserialize opportunistically to Path objects where possible. The idea is that once the values are loaded and validated from the config the rest of the code doesn't have to worry. They are proper Path objects.
1. Fix up all the call patterns to use Path objects if possible. In some cases it relies on external helpers (such as file crawlers) which expect a string. For those use cases, rather than rewrite the functions I opted to just convert to strings as needed.
1. There were a few minor typing issues that my IDE identified that I have fixed here and there on the fly.

## Testing

* I have tried setting a wallpaper after starting without an initial config file.
* Set wallpaper by cursor or keyboard for all monitors and each monitor individually. 
* If you change the folder without a wallpaper being already set empty string is saved as the current wallpaper as expected (and existing behavior)
* List argument returns proper list when wallpapers are set