### PR TITLE
Add mpvpaper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ GUI wallpaper setter for Wayland and Xorg window managers. It works as a fronten
 
 - Vim keys
 - Support for GIF animations (with `swww`)
+- Support for videos (with `mpvpaper`)
 - Support for multiple monitors (with `swww`)
-- Works on Wayland (with `swww` or `swaybg` or `hyprpaper` or `wallutils`)
+- Works on Wayland (with `swww` or `swaybg` or `hyprpaper` or `wallutils` or `mpvpaper`)
 - Works on Xorg (with `feh` or `wallutils`)
 - Restores wallpaper at launch of your WM
 - Caching for fast loading
-  
+
 ## Installation
 
 You need to install at least one of the backends and Waypaper, which works as a frontend.
 
 ### 1. Install a backend
 
-Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [feh](https://github.com/derf/feh) on Xorg or [wallutils](https://github.com/xyproto/wallutils) on both.
+Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [feh](https://github.com/derf/feh) on Xorg or [mpvpaper](https://github.com/GhostNaN/mpvpaper) or [wallutils](https://github.com/xyproto/wallutils) on both.
 
 ### 2. Install Waypaper
 
@@ -52,7 +53,7 @@ Waypaper is available in an external repository owned by Solopasha. You can add 
 
 ### Dependencies
 
-- `swww` or `swaybg` or `feh` or `wallutils` or `hyprpaper`
+- `swww` or `swaybg` or `feh` or `wallutils` or `hyprpaper` or `mpvpaper`
 - gobject python library (it might be called `python-gobject` or `python3-gi` or `python3-gobject` in your package manager.)
 - `python-importlib_metadata`
 - `python-platformdirs`

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
             "waypaper = waypaper.__main__:run"
         ]
     },
-    install_requires=["PyGObject", "importlib_metadata", "platformdirs", "Pillow"],
+    install_requires=["PyGObject", "importlib_metadata", "platformdirs", "Pillow", "opencv-python-headless"],
     version='2.3',
     python_requires='>3.9',
     classifiers=[

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -12,7 +12,7 @@ from waypaper.aboutdata import AboutData
 from waypaper.changer import change_wallpaper
 from waypaper.config import Config
 from waypaper.common import get_image_paths, get_random_file, get_monitor_names_hyprctl, get_monitor_names_swww
-from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS
+from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 
 gi.require_version("Gtk", "3.0")
@@ -43,6 +43,8 @@ def cache_image(image_path: str, cache_dir: Path) -> None:
     try:
         if ext == ".webp":
             pixbuf = read_webp_image(str(image_path))
+        elif ext in VIDEO_EXTENSIONS:
+            pixbuf = read_video_frame(str(image_path), cache_dir)
         else:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(image_path))
 

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -2,6 +2,7 @@
 
 import threading
 import os
+import cv2
 import gi
 import shutil
 from pathlib import Path
@@ -26,6 +27,15 @@ def read_webp_image(image_path: str) -> GdkPixbuf:
     pixbuf = GdkPixbuf.Pixbuf.new_from_data(data, GdkPixbuf.Colorspace.RGB, False, 8, width, height, width * 3)
     return pixbuf
 
+def read_video_frame(image_path: str, cache_dir: Path) -> GdkPixbuf:
+    """Read first frame of video and convert it inot pixbuf format"""
+    temp_frame = cache_dir / "temp_frame.jpeg"
+    vidcap = cv2.VideoCapture(image_path)
+    _, image = vidcap.read()
+    cv2.imwrite(temp_frame, image)
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(temp_frame)
+    os.remove(temp_frame)
+    return pixbuf
 
 def cache_image(image_path: str, cache_dir: Path) -> None:
     """Resize and cache images using gtk library"""

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -2,7 +2,6 @@
 
 import threading
 import os
-import cv2
 import gi
 import shutil
 from pathlib import Path
@@ -29,6 +28,7 @@ def read_webp_image(image_path: str) -> GdkPixbuf:
 
 def read_video_frame(image_path: str, cache_dir: Path) -> GdkPixbuf:
     """Read first frame of video and convert it inot pixbuf format"""
+    import cv2
     temp_frame = cache_dir / "temp_frame.jpeg"
     vidcap = cv2.VideoCapture(image_path)
     _, image = vidcap.read()

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -43,8 +43,17 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|En
             except subprocess.CalledProcessError:
                 pass
 
+            fill_types = {
+                    "fill": "panscan=1.0",
+                    "fit": "panscan=0.0",
+                    "center": "",
+                    "stretch": "--keepaspect=no",
+                    "tile": "",
+            }
+            fill = fill_types[cf.fill_option.lower()]
+
             command = ["mpvpaper"]
-            command.extend(["-o", f"no-audio loop"])
+            command.extend(["-o", f"no-audio loop {fill}"])
             # if monitor != "All":
             #     command.extend([monitor])
             # else:

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -53,7 +53,7 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|En
             fill = fill_types[cf.fill_option.lower()]
 
             command = ["mpvpaper"]
-            command.extend(["-o", f"no-audio loop {fill}"])
+            command.extend(["-o", f"no-audio loop {fill} --background-color='{cf.color}'"])
             # if monitor != "All":
             #     command.extend([monitor])
             # else:

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import re
 
 def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|English|French|German|Polish|Russian|Belarusian):
-
     """Run system commands to change the wallpaper depending on the backend"""
 
     try:
@@ -30,6 +29,28 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|En
                 # command.extend(["-o", monitor])
             command.extend(["-i", str(image_path)])
             command.extend(["-m", fill, "-c", cf.color])
+            subprocess.Popen(command)
+            print(f"{txt.msg_setwith} {cf.backend}")
+
+        # mpvpaper backend:
+        elif cf.backend == "mpvpaper":
+
+            # Kill previous mpvpaper instances:
+            try:
+                subprocess.check_output(["pgrep", "mpvpaper"], encoding='utf-8')
+                subprocess.Popen(["killall", ".mpvpaper-wrapp"])
+                time.sleep(0.5)
+            except subprocess.CalledProcessError:
+                pass
+
+            command = ["mpvpaper"]
+            command.extend(["-o", f"no-audio loop"])
+            # if monitor != "All":
+            #     command.extend([monitor])
+            # else:
+            #     command.extend('*')
+            command.extend('*')
+            command.extend([image_path])
             subprocess.Popen(command)
             print(f"{txt.msg_setwith} {cf.backend}")
 
@@ -119,7 +140,7 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str, txt: Chinese|En
                 subprocess.Popen(["hyprpaper"])
                 time.sleep(1)
             preload_command = ["hyprctl", "hyprpaper", "preload", image_path]
-            
+
             # Decide which monitors are affected:
             if monitor == "All":
                 monitors = get_monitor_names_hyprctl()

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "wallutils", "hyprpaper"]
+BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "wallutils", "hyprpaper", "mpvpaper"]
 FILL_OPTIONS: List[str] = ["fill", "stretch", "fit", "center", "tile"]
 SORT_OPTIONS: List[str] = ["name", "namerev", "date", "daterev"]
 SORT_DISPLAYS: Dict[str, str] = {
@@ -20,6 +20,7 @@ IMAGE_EXTENSIONS: Dict[BACKEND_OPTIONS, List[str]] = {
         BACKEND_OPTIONS[3]: ['.gif', '.jpg', '.jpeg', '.png', '.bmp', '.pnm', '.tiff'],
         BACKEND_OPTIONS[4]: ['.gif', '.jpg', '.jpeg', '.png'],
         BACKEND_OPTIONS[5]: ['.jpg', '.jpeg', '.png', '.webp'],
+        BACKEND_OPTIONS[6]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff'] + VIDEO_EXTENSIONS,
         }
 
 SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "left", "right", "top",

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -8,6 +8,11 @@ SORT_DISPLAYS: Dict[str, str] = {
                 "date": "Date ↓",
                 "daterev": "Date ↑"}
 
+VIDEO_EXTENSIONS: List[str] = ['webm', 'mkv', 'flv', 'vob', 'ogv', 'ogg', 'rrc', 'gifv', 'mng', 'mov',
+                               'avi', 'qt', 'wmv', 'yuv', 'rm', 'asf', 'amv', 'mp4', 'm4p', 'm4v',
+                               'mpg', 'mp2', 'mpeg', 'mpe', 'mpv', 'm4v', 'svi', '3gp', '3g2', 'mxf',
+                               'roq', 'nsv', 'flv', 'f4v', 'f4p', 'f4a', 'f4b', 'mod' ]
+
 IMAGE_EXTENSIONS: Dict[BACKEND_OPTIONS, List[str]] = {
         BACKEND_OPTIONS[0]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff'],
         BACKEND_OPTIONS[1]: ['.gif', '.jpg', '.jpeg', '.png'],

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -8,10 +8,10 @@ SORT_DISPLAYS: Dict[str, str] = {
                 "date": "Date ↓",
                 "daterev": "Date ↑"}
 
-VIDEO_EXTENSIONS: List[str] = ['webm', 'mkv', 'flv', 'vob', 'ogv', 'ogg', 'rrc', 'gifv', 'mng', 'mov',
-                               'avi', 'qt', 'wmv', 'yuv', 'rm', 'asf', 'amv', 'mp4', 'm4p', 'm4v',
-                               'mpg', 'mp2', 'mpeg', 'mpe', 'mpv', 'm4v', 'svi', '3gp', '3g2', 'mxf',
-                               'roq', 'nsv', 'flv', 'f4v', 'f4p', 'f4a', 'f4b', 'mod' ]
+VIDEO_EXTENSIONS: List[str] = ['.webm', '.mkv', '.flv', '.vob', '.ogv', '.ogg', '.rrc', '.gifv', '.mng', '.mov',
+                               '.avi', '.qt', '.wmv', '.yuv', '.rm', '.asf', '.amv', '.mp4', '.m4p', '.m4v',
+                               '.mpg', '.mp2', '.mpeg', '.mpe', '.mpv', '.m4v', '.svi', '.3gp', '.3g2', '.mxf',
+                               '.roq', '.nsv', '.flv', '.f4v', '.f4p', '.f4a', '.f4b', '.mod' ]
 
 IMAGE_EXTENSIONS: Dict[BACKEND_OPTIONS, List[str]] = {
         BACKEND_OPTIONS[0]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff'],


### PR DESCRIPTION
Fix for #12.

Mpvpaper supports:
- fill types: fill, fit, stretch
- background color
- both video and image as wallpaper
- ~~multimonitor support~~

Notes:
Although mpvpaper itself supports multi-monitor support it is not implemented in waypaper yet. This is mainly because I couldn't understand why in `common.py:123` the `get_monitor_names()` is divided into two funtions, wouldn't it be better to use the same function and doesn't rely on either swww or hyprctl? Sorry if this is a stupid question but is there a reason to do so?
Also maybe for the same reason multi-monitor support is not implemented in swaybg although it supports it.