### PR TITLE
Fixed Issue with CMD Support for Multi-Monitor using state files.

### DIFF
--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -123,6 +123,7 @@ class Config:
         self.image_folder = pathlib.Path(image_folder_str).expanduser()
         if monitors_str:
             self.monitors = [str(monitor) for monitor in monitors_str.split(",")]
+            self.selected_monitor = self.monitors[0]
         if wallpapers_str:
             self.wallpapers = [pathlib.Path(paper).expanduser() for paper in wallpapers_str.split(",")]
 


### PR DESCRIPTION
Initial proposal to fix #89 

I have on load of a state file set the `self.selected_monitor` in waypaper/config.py to the first index of the monitor list, not perfect, but without a routine to keep track of what monitors are being addressed per state-file, it's what I can do for now. 

I can look into or implement a different solution, upon request. But this currently works, to fix my bug. Further testing should be done to ensure this doesn't break anything else. 