### PR TITLE
fix: config won't load if they're not backends detected

### DIFF
--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -22,7 +22,11 @@ class Config:
         self.selected_monitor = "All"
         self.fill_option = FILL_OPTIONS[0]
         self.sort_option = SORT_OPTIONS[0]
-        self.backend = self.installed_backends[1] if self.installed_backends else BACKEND_OPTIONS[0]
+        self.backend = (
+            self.installed_backends[1]
+            if len(self.installed_backends) > 1
+            else BACKEND_OPTIONS[0]
+        )
         self.color = "#ffffff"
         self.number_of_columns = 3
         self.swww_transition_type = SWWW_TRANSITION_TYPES[0]


### PR DESCRIPTION
Even when setting `backend = none` in your config, the program refuses to start since it assumes it has detected at least 1 backend, which with the "none" backend would make it 2. "none" isn't really a backend though, and the code on `__init__` fails if no backends were detected before it has the chance to load the config.