### PR TITLE
Mark AVIF as supported by mpvpaper backend

### DIFF
--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -21,7 +21,7 @@ IMAGE_EXTENSIONS: Dict[str, List[str]] = {
         BACKEND_OPTIONS[3]: ['.gif', '.jpg', '.jpeg', '.png', '.bmp', '.pnm', '.tiff'],
         BACKEND_OPTIONS[4]: ['.gif', '.jpg', '.jpeg', '.png'],
         BACKEND_OPTIONS[5]: ['.jpg', '.jpeg', '.png', '.webp'],
-        BACKEND_OPTIONS[6]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff'] + VIDEO_EXTENSIONS,
+        BACKEND_OPTIONS[6]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff', '.avif'] + VIDEO_EXTENSIONS,
         }
 
 SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "left", "right", "top",


### PR DESCRIPTION
As mpvpaper supports both static and animated AVIF, I wanted to add it.
I'm too much of a skill issue to properly convert my videos to WEBP or GIF without losing quality or getting terrifying file sizes, so here I am.
Already tested, worky and thumbnail generation is hitchless.
Thank you for your time.