### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `waypaper` package is available thanks to Basil Keeler.
 
 #### On OpenSUSE
 
-Users of OpenSUSE [reported issue with installation](https://github.com/anufrievroman/waypaper/issues/30) via `pipx install waypaper`. This might be resolved by installing the `python311-pycairo-devel` package.
+Users of OpenSUSE [reported issue with installation](https://github.com/anufrievroman/waypaper/issues/30) via `pipx install waypaper`. This can be resolved by installing the `python311-pycairo-devel` and `python312-gobject-devel` packages first.
 
 #### On Fedora
 


### PR DESCRIPTION
Update OpenSuse Section of README.md to include python312-gobject-devel package.