### PR TITLE
Fix bug by using glob function that follows symlinks.

### DIFF
--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -4,7 +4,10 @@ import os
 import random
 import shutil
 from pathlib import Path
+
+from pathlib import Path
 from typing import List
+from glob import glob
 
 from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS
 
@@ -23,8 +26,9 @@ def get_image_paths(backend: str,
                     only_gifs: bool = False,
                     depth: int = 1):
     """Get a list of file paths depending on the filters that were requested"""
+    if depth < 0:
+        return get_image_paths_infinite_recursion(backend, root_folder, include_hidden, only_gifs)
     image_paths = []
-
     for root, directories, files in os.walk(root_folder):
         # Remove hidden files from consideration:
         for directory in directories:
@@ -37,7 +41,8 @@ def get_image_paths(backend: str,
 
         # Remove deep folders from consideration:
         if depth is not None and root != root_folder:
-            current_depth = root.count(os.path.sep) - str(root_folder).count(os.path.sep)
+            current_depth = root.count(os.path.sep) - str(root_folder).count(
+                os.path.sep)
             if current_depth > depth:
                 continue
 
@@ -52,6 +57,24 @@ def get_image_paths(backend: str,
             image_paths.append(os.path.join(root, filename))
         # print(root, directories, files)
     return image_paths
+
+
+def get_image_paths_infinite_recursion(backend: str,
+                    root_folder: str,
+                    include_hidden: bool = False,
+                    only_gifs: bool = False):
+    """Get a list of file paths depending on the filters that were requested"""
+    paths = os.walk(root_folder, followlinks=True)
+    paths = map(lambda x: map(lambda y: os.path.join(x[0], y), x[2]), paths)
+    paths = [ x for xs in paths for x in xs ]
+    print(paths)
+    if only_gifs:
+        paths = list(filter(lambda f: f.lower().endswith(".gif"),paths))
+    else:
+        paths = list(filter(lambda x: has_image_extension(x, backend), paths))
+    if not include_hidden:
+        paths = list(filter(lambda x: not x.startswith(".") , paths))
+    return paths
 
 
 def get_random_file(backend: str,


### PR DESCRIPTION
I changed the function from glob.glob to pahtlib.Path.glob and use the argument that follows symlinks and filtered the files manually. Fixes #132.