### PR TITLE
Added a keyword to the desktop file to help with the search in dmenu's

### DIFF
--- a/data/waypaper.desktop
+++ b/data/waypaper.desktop
@@ -8,4 +8,5 @@ Icon=waypaper
 Terminal=false
 GenericName=Waypaper wallpaper setter
 Categories=Utility;GTK;DesktopSettings;
+Keywords=wallpapers;
 Comment=Change wallpaper on Wayland and X11


### PR DESCRIPTION
I always forget the name of the app and this change helps me find it in [tofi](https://github.com/philj56/tofi).
Used `wallpapers` instead of `wallpaper` to be more forgiving to user input.