### PR TITLE
prevent crashing when screeninfo fails

### DIFF
--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -11,7 +11,7 @@ from waypaper.app import App
 from waypaper.changer import change_wallpaper
 from waypaper.common import get_random_file
 from waypaper.config import Config
-from waypaper.options import BACKEND_OPTIONS, FILL_OPTIONS, MONITOR_OPTIONS
+from waypaper.options import BACKEND_OPTIONS, FILL_OPTIONS, get_monitor_options
 from waypaper.translations import load_language
 
 
@@ -36,7 +36,7 @@ parser.add_argument("--folder", help=txt.msg_arg_folder, nargs="+", default = []
 parser.add_argument("--state-file", help=txt.msg_arg_statefile)
 parser.add_argument("--backend", help=txt.msg_arg_back, choices=BACKEND_OPTIONS)
 parser.add_argument("--list", help=txt.msg_arg_list, action='store_true')
-parser.add_argument("--monitor", help=txt.msg_arg_monitor, choices=MONITOR_OPTIONS)
+parser.add_argument("--monitor", help=txt.msg_arg_monitor, choices=get_monitor_options())
 parser.add_argument("--no-post-command", help=txt.msg_arg_post, action='store_true')
 args = parser.parse_args()
 

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -6,13 +6,12 @@ import os
 import gi
 import shutil
 import imageio
-import screeninfo
 from pathlib import Path
 
 from waypaper.changer import change_wallpaper
 from waypaper.config import Config
 from waypaper.common import get_image_paths, get_image_name, get_random_file, cache_image
-from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS , SWWW_TRANSITION_TYPES
+from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS , SWWW_TRANSITION_TYPES, get_monitors
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 
 gi.require_version("Gtk", "3.0")
@@ -330,7 +329,7 @@ class App(Gtk.Window):
         monitor_names = ["All"]
         if self.cf.backend in ["feh", "wallutils", "none"]:
             return
-        monitor_names.extend([m.name for m in screeninfo.get_monitors()])
+        monitor_names.extend([m.name for m in get_monitors()])
 
         # Create a monitor option dropdown menu:
         self.monitor_option_combo = Gtk.ComboBoxText()

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -1,13 +1,12 @@
 """Module that contains lists of possible options used in the application"""
 
 from typing import List, Dict
-from screeninfo import get_monitors
+from screeninfo import get_monitors as _get_monitors
 
 BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "wallutils", "hyprpaper", "mpvpaper"]
 FILL_OPTIONS: List[str] = ["fill", "stretch", "fit", "center", "tile"]
 SORT_OPTIONS: List[str] = ["name", "namerev", "date", "daterev"]
 SORT_DISPLAYS: Dict[str, str] = {"name": "Name ↓", "namerev": "Name ↑", "date": "Date ↓", "daterev": "Date ↑"}
-MONITOR_OPTIONS: List[str] = [m.name for m in get_monitors()]
 
 VIDEO_EXTENSIONS: List[str] = ['.webm', '.mkv', '.flv', '.vob', '.ogv', '.ogg', '.rrc', '.gifv', '.mng', '.mov',
                                '.avi', '.qt', '.wmv', '.yuv', '.rm', '.asf', '.amv', '.mp4', '.m4p', '.m4v',
@@ -29,3 +28,16 @@ SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "l
 
 TIMERS: Dict[str, int] = {"30 sec": 30, "1 min": 60, "2 min": 120, "5 min": 300, "10 min": 600, "30 min": 1800, "1 hour": 3600,
           "2 hours": 7200, "6 hours": 21600, "12 hours": 43200, "1 day": 86400, "1 week": 604800}
+
+def get_monitors() -> List[str]:
+    """Get a list of monitor names using screeninfo. Returns a list of monitor names or an empty list if an error occurs."""
+    try:
+        return [m.name for m in _get_monitors()]
+    except Exception as e:
+        print(f"Error fetching monitors with screeninfo: {e}. Falling back to 'All'.")
+        return []
+
+def get_monitor_options() -> List[str]:
+    """Get a list of available monitors for the CLI."""
+    mons = get_monitors()
+    return ["All"] + mons if mons else ["All"]


### PR DESCRIPTION
this mostly addresses the issues raised in #120 and #163, without over-complicating things too much. 

this handles the exceptions caused by the upstream package a bit more gracefully. Instead of crashing right out of the gate, we swallow the exception and fallback to "All" as the default monitor option, regardless of backend.

When an exception is caught, a simple warning is printed with the exception message. 

you _could_ argue that this breaks multi-monitor support, but this will only happen in cases where the application is already crashing, so a net positive IMO 🙂 

Let me know if there's any questions!