### PR TITLE
Take hash of image path for cache path

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from waypaper.changer import change_wallpaper
 from waypaper.config import Config
-from waypaper.common import get_image_paths, get_image_name, get_random_file, cache_image
+from waypaper.common import get_image_paths, get_image_name, get_random_file, cache_image, get_cached_image_path
 from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS , SWWW_TRANSITION_TYPES, get_monitors
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 
@@ -459,7 +459,7 @@ class App(Gtk.Window):
                 continue
 
             # If this image is not cached yet, resize and cache it:
-            cached_image_path = self.cf.cache_dir / os.path.basename(image_path)
+            cached_image_path = get_cached_image_path(image_path, self.cf.cache_dir)
             if not cached_image_path.exists():
                 cache_image(image_path, self.cf.cache_dir)
 

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -64,7 +64,7 @@ def get_image_paths(backend: str,
 
 def get_image_name(full_path: str, base_folder_list: list[Path], include_path: bool) ->  str:
     """Get image name that may or may not include parent folders"""
-    full_path = Path(full_path).resolve()
+    full_path = Path(os.path.normpath(full_path)).absolute()
 
     # If path is not required, just return file name:
     if not include_path:
@@ -72,7 +72,7 @@ def get_image_name(full_path: str, base_folder_list: list[Path], include_path: b
 
     # Otherwise, find from which folder file comes from and append this folder:
     for base_folder in base_folder_list:
-        base_folder = Path(base_folder).resolve()
+        base_folder = Path(os.path.normpath(base_folder)).absolute()
         if not full_path.is_relative_to(base_folder):
             continue
         common_folder = base_folder.name

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -5,6 +5,7 @@ import gi
 import random
 import shutil
 import imageio
+import hashlib
 from pathlib import Path
 from typing import List
 from PIL import Image
@@ -137,10 +138,15 @@ def check_installed_backends() -> List[str]:
     return installed_backends
 
 
+def get_cached_image_path(image_path: str, cache_dir: Path) -> Path:
+    real_path_bytes = bytes(os.path.realpath(image_path), encoding="UTF-8")
+    return cache_dir / f"{hashlib.md5(real_path_bytes, usedforsecurity=False).hexdigest()}.jpg"
+
+
 def cache_image(image_path: str, cache_dir: Path) -> None:
     """Create small copies of images using various libraries depending on the file type"""
     ext = os.path.splitext(image_path)[1].lower()
-    cache_file = cache_dir / Path(os.path.basename(image_path))
+    cache_file = get_cached_image_path(image_path, cache_dir)
     width = 240
     try:
         # If it's a video, extract the first frame:


### PR DESCRIPTION
I noticed that images with the same file name in different subfolders would share thumbnail icons. To fix this, I made the filename of the thumbnail be the md5 hash of the real path of the image.

Opted for md5 hash instead of replacing "/" with "\_" (or similar approach) because that has issues with collisions for regular use of an "\_", and could run into path length issues.

I think there are many ways of solving this problem, feedback welcomed!

(also sneaking in a fix for symlinks within subdirectories causing None image names)