### PR TITLE
Fixed JPEG encoding fails due to Glycin no longer supporting Rgba8

### DIFF
--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -159,18 +159,14 @@ def cache_image(image_path: str, cache_dir: Path) -> None:
         if ext == ".webp":
             img = Image.open(image_path)
             data = img.tobytes()
-
             img_width, img_height = img.size
-            has_alpha = img.has_transparency_data
-            rowstride = img_width * (3 + int(has_alpha))
-
-            pixbuf = GdkPixbuf.Pixbuf.new_from_data(data, GdkPixbuf.Colorspace.RGB, has_alpha, 8, img_width, img_height, rowstride)
+            pixbuf = GdkPixbuf.Pixbuf.new_from_data(data, GdkPixbuf.Colorspace.RGB, False, 8, img_width, img_height, img_width * 3)
         else:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(str(image_path))
         aspect_ratio = pixbuf.get_width() / pixbuf.get_height()
         height = int(width / aspect_ratio)
         scaled_pixbuf = pixbuf.scale_simple(width, height, GdkPixbuf.InterpType.BILINEAR)
-        scaled_pixbuf.savev(str(cache_file), "jpeg", [], [])
+        scaled_pixbuf.savev(str(cache_file), "png", [], [])
 
     # If image processing failed, create a black placeholder:
     except Exception as e:
@@ -178,4 +174,4 @@ def cache_image(image_path: str, cache_dir: Path) -> None:
         print(e)
         black_pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, width, width*9/16)
         black_pixbuf.fill(0x0)
-        black_pixbuf.savev(str(cache_file), "jpeg", [], [])
+        black_pixbuf.savev(str(cache_file), "png", [], [])


### PR DESCRIPTION
### 🐛 Bug: JPEG encoding fails due to Glycin no longer supporting Rgba8

After a recent system upgrade on Arch Linux (via pacman), Waypaper started failing to generate image previews or cache thumbnails. The error occurs when trying to save a preview image as JPEG using `savev()`, due to a change in the underlying image loader — now based on Glycin.

The problem appears to be that Glycin no longer supports encoding JPEG images with the `Rgba8` color type, which causes `savev(..., "jpeg", ...)` to throw a GLib.GError.

---

### 📜 Full error log

```
(waypaper:75951): Gtk-WARNING **: Theme parsing error: gtk-dark.css:6754:15: Junk at end of value for padding
Could not generate preview for wallhaven-je3o9y.png
gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: glycin-loaders/glycin-image-rs/src/editor.rs:129:22: Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8`

stderr:
Setting process memory limit
 (0)
Exception in thread Thread-1 (process_images):
Traceback (most recent call last):
  File "/home/USER/.local/share/pipx/venvs/waypaper/lib/python3.13/site-packages/waypaper/common.py", line 169, in cache_image
    scaled_pixbuf.savev(str(cache_file), "jpeg", [], [])
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: ...The encoder or decoder for Jpeg does not support the color type `Rgba8`

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
  File "/home/USER/.local/share/pipx/venvs/waypaper/lib/python3.13/site-packages/waypaper/app.py", line 456, in process_images
    cache_image(image_path, self.cf.cache_dir)
  File "/home/USER/.local/share/pipx/venvs/waypaper/lib/python3.13/site-packages/waypaper/common.py", line 177, in cache_image
    black_pixbuf.savev(str(cache_file), "jpeg", [], [])
gi.repository.GLib.GError: gly-loader-error: Remote error: org.gnome.glycin.Error.InternalEditorError: ...The encoder or decoder for Jpeg does not support the color type `Rgba8`
```

### ✅ Temporary workaround

In `waypaper/common.py`, changing:

```python
scaled_pixbuf.savev(str(cache_file), "jpeg", [], [])
```

to:

```python
scaled_pixbuf.savev(str(cache_file), "png", [], [])
```
and

```python
black_pixbuf.savev(str(cache_file), "jpeg", [], [])
```

to:

```python
black_pixbuf.savev(str(cache_file), "png", [], [])
```

fixes the issue by avoiding JPEG encoding entirely.

<img width="2496" height="832" alt="Image" src="https://github.com/user-attachments/assets/14a8acec-8365-4841-98af-cb664cd709a5" />