### PR TITLE
feat: add basic xwallpaper backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Waypaper
 
-GUI wallpaper setter for Wayland and Xorg window managers. It works as a frontend for popular wallpaper backends like `swaybg`, `swww`, `wallutils`, `hyprpaper`, `mpvpaper` and `feh`. See [demo](https://www.youtube.com/watch?v=O9OL7iH_KVY) and [documentation](https://anufrievroman.gitbook.io/waypaper).
+GUI wallpaper setter for Wayland and Xorg window managers. It works as a frontend for popular wallpaper backends like `swaybg`, `swww`, `wallutils`, `hyprpaper`, `mpvpaper`, `xwallpaper` and `feh`. See [demo](https://www.youtube.com/watch?v=O9OL7iH_KVY) and [documentation](https://anufrievroman.gitbook.io/waypaper).
 
 ![screenshot](screen.jpg)
 
@@ -11,7 +11,7 @@ GUI wallpaper setter for Wayland and Xorg window managers. It works as a fronten
 - Supports videos (with `mpvpaper`)
 - Supports multiple monitors (with `swww` or `swaybg` or `hyprpaper` or `mpvpaper`)
 - Works on Wayland (with `swww` or `swaybg` or `hyprpaper` or `wallutils` or `mpvpaper`)
-- Works on Xorg (with `feh` or `wallutils`)
+- Works on Xorg (with `feh`, `xwallpaper` or `wallutils`)
 - Restores wallpaper after restart (`waypaper --restore`)
 - Fast and minimal (315 kB)
 
@@ -21,7 +21,7 @@ Install at least one of the backends and Waypaper, which works as a frontend.
 
 ### 1. Install a backend
 
-Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [feh](https://github.com/derf/feh) on Xorg or [mpvpaper](https://github.com/GhostNaN/mpvpaper) or [wallutils](https://github.com/xyproto/wallutils) on both.
+Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [xwallpaper](https://github.com/stoeckmann/xwallpaper) or [feh](https://github.com/derf/feh) on Xorg or [mpvpaper](https://github.com/GhostNaN/mpvpaper) or [wallutils](https://github.com/xyproto/wallutils) on both.
 
 ### 2. Install Waypaper
 
@@ -53,7 +53,7 @@ Waypaper is available in an external repository owned by Solopasha. You can add 
 
 ### Dependencies
 
-- `swww` or `swaybg` or `feh` or `wallutils` or `hyprpaper` or `mpvpaper`
+- `swww` or `swaybg` or `xwallpaper` or `feh` or `wallutils` or `hyprpaper` or `mpvpaper`
 - gobject python library (it might be called `python-gobject` or `python3-gi` or `python3-gobject` in your package manager.)
 - `python-imageio`
 - `python-imageio-ffmpeg`

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -173,6 +173,23 @@ def change_with_feh(image_path: Path, cf: Config, monitor: str):
     command.extend([str(image_path)])
     subprocess.Popen(command)
 
+def change_with_xwallpaper(image_path: Path, cf: Config, monitor: str):
+    """Change wallpaper with xwallpaper backend"""
+
+    fill_types = {
+            "fill": "--zoom",
+            "fit": "--maximize",
+            "center": "--center",
+            "stretch": "--stretch",
+            "tile": "--tile",
+            }
+    fill = fill_types[cf.fill_option.lower()]
+    # Since xwallpaper doesn't accept 'All', but 'all'
+    if monitor == "All":
+        monitor = "all"
+    command = ["xwallpaper", "--output", monitor, fill]
+    command.extend([str(image_path)])
+    subprocess.Popen(command)
 
 def change_with_wallutils(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with wallutils backend"""
@@ -245,6 +262,8 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
             change_with_swww(image_path, cf, monitor)
         if cf.backend == "feh":
             change_with_feh(image_path, cf, monitor)
+        if cf.backend == "xwallpaper":
+            change_with_xwallpaper(image_path, cf, monitor)
         if cf.backend == "wallutils":
             change_with_wallutils(image_path, cf, monitor)
         if cf.backend == "hyprpaper":

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -5,7 +5,7 @@ import subprocess
 from typing import List, Dict
 
 
-BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "wallutils", "hyprpaper", "mpvpaper", "macos"]
+BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "xwallpaper", "wallutils", "hyprpaper", "mpvpaper", "macos"]
 FILL_OPTIONS: List[str] = ["fill", "stretch", "fit", "center", "tile"]
 SORT_OPTIONS: List[str] = ["name", "namerev", "date", "daterev", "random"]
 SORT_DISPLAYS: Dict[str, str] = {"name": "Name ↓", "namerev": "Name ↑", "date": "Date ↓", "daterev": "Date ↑", "random": "Random"}


### PR DESCRIPTION
I added a basic **xwallpaper** backend implementation.
As requested in the issue #193.
It supports selecting the monitor and the following options:
- zoom
- maximize
- center
- stretch
- tile