### PR TITLE
Add gSlapper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Waypaper
 
-GUI wallpaper setter for Wayland and Xorg window managers. It works as a frontend for popular wallpaper backends like `swaybg`, `swww`, `wallutils`, `hyprpaper`, `mpvpaper`, `gslapper`, `xwallpaper` and `feh`. See [demo](https://www.youtube.com/watch?v=O9OL7iH_KVY) and [documentation](https://anufrievroman.gitbook.io/waypaper).
+GUI wallpaper setter for Wayland and Xorg window managers. It works as a frontend for popular wallpaper backends like `swaybg`, `swww`, `wallutils`, `hyprpaper`, `mpvpaper`, `xwallpaper` and `feh`. See [demo](https://www.youtube.com/watch?v=O9OL7iH_KVY) and [documentation](https://anufrievroman.gitbook.io/waypaper).
 
 ![screenshot](screen.jpg)
 
 ## Features
 
 - Vim keys
-- Supports GIF animations (with `swww` or `mpvpaper` or `gslapper`)
-- Supports videos (with `mpvpaper` or `gslapper`)
-- Supports multiple monitors (with `swww` or `swaybg` or `hyprpaper` or `mpvpaper` or `gslapper`)
-- Works on Wayland (with `swww` or `swaybg` or `hyprpaper` or `wallutils` or `mpvpaper` or `gslapper`)
+- Supports GIF animations (with `swww` or `mpvpaper`)
+- Supports videos (with `mpvpaper`)
+- Supports multiple monitors (with `swww` or `swaybg` or `hyprpaper` or `mpvpaper`)
+- Works on Wayland (with `swww` or `swaybg` or `hyprpaper` or `wallutils` or `mpvpaper`)
 - Works on Xorg (with `feh`, `xwallpaper` or `wallutils`)
 - Restores wallpaper after restart (`waypaper --restore`)
 - Fast and minimal (315 kB)
@@ -21,7 +21,7 @@ Install at least one of the backends and Waypaper, which works as a frontend.
 
 ### 1. Install a backend
 
-Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [xwallpaper](https://github.com/stoeckmann/xwallpaper) or [feh](https://github.com/derf/feh) on Xorg or [mpvpaper](https://github.com/GhostNaN/mpvpaper) or [gslapper](https://github.com/Nomadcxx/gSlapper) or [wallutils](https://github.com/xyproto/wallutils) on both.
+Install a preferred backend from your package manager: [swww](https://github.com/Horus645/swww) or [swaybg](https://github.com/swaywm/swaybg) or [hyprpaper](https://github.com/hyprwm/hyprpaper) on Wayland or [xwallpaper](https://github.com/stoeckmann/xwallpaper) or [feh](https://github.com/derf/feh) on Xorg or [mpvpaper](https://github.com/GhostNaN/mpvpaper) or [wallutils](https://github.com/xyproto/wallutils) on both.
 
 ### 2. Install Waypaper
 

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -626,12 +626,21 @@ class App(Gtk.Window):
 
 
     def on_mpv_sound_toggled(self, toggle) -> None:
-        """Toggle sound of mpv player"""
+        """Toggle sound of mpv player or gSlapper"""
         self.cf.mpvpaper_sound = toggle.get_active()
         if self.cf.backend == "mpvpaper":
             subprocess.Popen(f"echo 'cycle mute' | socat - /tmp/mpv-socket-{self.cf.selected_monitor}", shell=True)
         elif self.cf.backend == "gslapper":
-            subprocess.Popen(f"echo 'cycle mute' | socat - /tmp/gst-socket-{self.cf.selected_monitor}", shell=True)
+            # For gSlapper, immediately restart with new audio setting
+            from waypaper.changer import change_with_gslapper
+            from pathlib import Path
+            
+            # Get current wallpaper path from config
+            if hasattr(self.cf, 'selected_wallpaper') and self.cf.selected_wallpaper:
+                try:
+                    change_with_gslapper(Path(self.cf.selected_wallpaper), self.cf, self.cf.selected_monitor)
+                except Exception as e:
+                    print(f"Could not restart gSlapper with new audio setting: {e}")
 
 
     def on_include_subfolders_toggled(self, toggle) -> None:
@@ -738,11 +747,12 @@ class App(Gtk.Window):
             subprocess.Popen(["killall", "gslapper"])
 
     def on_mpv_pause_button_clicked(self, widget) -> None:
-        """On clicking mpv pause button, pause mpvpaper or gslapper"""
+        """On clicking mpv pause button, pause mpvpaper or show not supported for gSlapper"""
         if self.cf.backend == "mpvpaper":
             subprocess.Popen(f"echo 'cycle pause' | socat - /tmp/mpv-socket-{self.cf.selected_monitor}", shell=True)
         elif self.cf.backend == "gslapper":
-            subprocess.Popen(f"echo 'cycle pause' | socat - /tmp/gst-socket-{self.cf.selected_monitor}", shell=True)
+            # gSlapper doesn't support pause, so do nothing or show message
+            print("Pause not supported for gSlapper")
 
     def on_random_clicked(self, widget) -> None:
         """On clicking random button, set random wallpaper"""

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -120,41 +120,52 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
 def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with gslapper backend"""
 
-    fill_types = {
-            "fill": "panscan=1.0",
-            "fit": "panscan=0.0",
-            "center": "",
-            "stretch": "--keepaspect=no",
-            "tile": "",
-            }
-    fill = fill_types[cf.fill_option.lower()]
+    # Map waypaper fill options to gSlapper options (using updated gSlapper capabilities):
+    fill_options = {
+        "fill": "panscan=1.0",      # Full screen coverage
+        "fit": "panscan=1.0",       # As you specified for proper video fitting  
+        "center": "original",       # Native resolution
+        "stretch": "stretch",       # New gSlapper stretch support
+        "tile": "panscan=1.0"       # Tiled behavior (using full coverage)
+    }
+    
+    # Get the gSlapper option for current fill setting:
+    gslapper_fill = fill_options.get(cf.fill_option.lower(), "panscan=1.0")
+    print(f"gSlapper fill option: {cf.fill_option} -> {gslapper_fill}")
 
-    # If gslapper is already active on given monitor, try to call that process:
-    try:
-        subprocess.check_output(["pgrep", "-f", f"gslapper.*{monitor}"], encoding='utf-8')
-        time.sleep(0.2)
-        print(f"Detected running gslapper on {monitor}, now trying to call gslapper socket")
-        subprocess.Popen(f"echo 'loadfile \"{image_path}\"' | socat - /tmp/gst-socket-{monitor}", shell=True)
+    # Kill any existing gSlapper process for this monitor:
+    seek_and_destroy("gslapper", monitor)
 
-    # If gslapper is not running, create a new process:
-    except subprocess.CalledProcessError:
-        print("Detected no running gslapper, starting new gslapper process")
-        command = ["gslapper", "--fork"]
-        if cf.mpvpaper_sound:
-            command.extend(["-o", f"input-ipc-server=/tmp/gst-socket-{monitor} {cf.mpvpaper_options} loop {fill} --background-color='{cf.color}'"])
-        else:
-            command.extend(["-o", f"input-ipc-server=/tmp/gst-socket-{monitor} {cf.mpvpaper_options} loop {fill} --mute=yes --background-color='{cf.color}'"])
-
-        # Specify the monitor:
-        if monitor == "All":
-            command.extend('*')
-        else:
-            command.extend([monitor])
-
-        command.extend([image_path])
-
-        print(f"{command=}")
-        subprocess.Popen(command)
+    # Build gSlapper command with proper options:
+    command = ["gslapper", "--fork"]
+    
+    # Build options list:
+    options = []
+    options.append("loop")  # Always loop videos
+    options.append(gslapper_fill)  # Add the fill/scaling option
+    
+    if not cf.mpvpaper_sound:  # If sound is OFF in UI
+        options.append("no-audio")
+    
+    # Add user's custom options if any:
+    if cf.mpvpaper_options.strip():
+        options.append(cf.mpvpaper_options.strip())
+    
+    # Build options string:
+    if options:
+        command.extend(["-o", " ".join(options)])
+    
+    # Specify the monitor:
+    if monitor == "All":
+        command.append('*')
+    else:
+        command.append(monitor)
+    
+    # Add the image/video path:
+    command.append(str(image_path))
+    
+    print(f"gSlapper command: {command}")
+    subprocess.Popen(command)
 
 
 def change_with_swww(image_path: Path, cf: Config, monitor: str):

--- a/waypaper/translations.py
+++ b/waypaper/translations.py
@@ -6,7 +6,7 @@ To add a new language, add a new class, and update the load_language() function.
 
 class English:
     def __init__(self):
-        self.msg_desc = "GUI wallpaper setter for Wayland and X11. It works as a frontend for feh, swaybg, wallutils, hyprpaper, mpvpaper, gslapper, and swww."
+        self.msg_desc = "GUI wallpaper setter for Wayland and X11. It works as a frontend for feh, swaybg, wallutils, hyprpaper, mpvpaper, and swww."
         self.msg_info = "For more information, visit:\nhttps://github.com/anufrievroman/waypaper"
 
         self.msg_arg_help = "print version of the program"
@@ -56,7 +56,7 @@ class English:
         self.err_backend += "Use your package manager to install at least one of these backends:\n\n"
         self.err_backend += "- swaybg (Wayland)\n- swww (Wayland)\n"
         self.err_backend += "- hyprpaper (Wayland)\n- feh (Xorg)\n"
-        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n- gslapper (Xorg & Wayland)\n\n"
+        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n\n"
         self.err_backend += self.msg_info
 
         self.tip_refresh = "Recache the folder of images"
@@ -68,7 +68,7 @@ class English:
         self.tip_random = "Set random wallpaper"
         self.tip_exit = "Exit the application"
         self.tip_transition = "Choose transition type"
-        self.tip_mpv_stop = "Stop all mpv/gstreamer processes"
+        self.tip_mpv_stop = "Stop all all mpv processes"
         self.tip_mpv_pause = "Play/Pause video wallpaper"
         self.tip_mpv_sound = "Play sound of the video"
         self.tip_timer = "How often to automatically change wallpaper"
@@ -77,7 +77,7 @@ class English:
 
 class German:
     def __init__(self):
-        self.msg_desc = "Grafisches Hintergrundbild-Auswahlwerkzeug für Wayland und X11. Es dient als Frontend für feh, swaybg, wallutils, hyprpaper, mpvpaper, gslapper, und swww."
+        self.msg_desc = "Grafisches Hintergrundbild-Auswahlwerkzeug für Wayland und X11. Es dient als Frontend für feh, swaybg, wallutils, hyprpaper, mpvpaper, und swww."
         self.msg_info = "Weitere Informationen finden Sie unter:\nhttps://github.com/anufrievroman/waypaper"
 
         self.msg_arg_help = "gibt die Programmversion aus"
@@ -128,7 +128,7 @@ class German:
         self.err_backend += "Installieren Sie mindestens eines der folgenden Backends:\n\n"
         self.err_backend += "- swaybg (Wayland)\n- swww (Wayland)\n"
         self.err_backend += "- hyprpaper (Wayland)\n- feh (Xorg)\n"
-        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n- gslapper (Xorg & Wayland)\n\n"
+        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n\n"
         self.err_backend += self.msg_info
 
         self.tip_refresh = "Erneutes einlesen des Hintergrundbild-Ordners"
@@ -140,7 +140,7 @@ class German:
         self.tip_random = "Ein zufälliges Hintergrundbild auswählen"
         self.tip_exit = "Das Programm beenden"
         self.tip_transition = "Übergangstyp auswählen"
-        self.tip_mpv_stop = "Stoppe alle mpv-/gstreamer-Prozesse"
+        self.tip_mpv_stop = "Stop allpe alle mpv-Prozesse"
         self.tip_mpv_pause = "Pause Video-Wallpaper"
         self.tip_mpv_sound = "Ton des Videos abspielen"
         self.tip_timer = "Wie oft das Hintergrundbild automatisch gewechselt wird"
@@ -148,7 +148,7 @@ class German:
 
 class French:
     def __init__(self):
-        self.msg_desc = "Sélecteur de papier peint graphique pour Wayland et X11. Il fonctionne comme une interface pour feh, swaybg, wallutils, hyprpaper, mpvpaper, gslapper, et swww."
+        self.msg_desc = "Sélecteur de papier peint graphique pour Wayland et X11. Il fonctionne comme une interface pour feh, swaybg, wallutils, hyprpaper, mpvpaper, et swww."
         self.msg_info = "Pour plus d'informations, visitez :\nhttps://github.com/anufrievroman/waypaper"
 
         self.msg_arg_help = "afficher la version du programme"
@@ -198,7 +198,7 @@ class French:
         self.err_backend += "Utilisez votre gestionnaire de paquets pour installer au moins l'un de ces backends :\n\n"
         self.err_backend += "- swaybg (Wayland)\n- swww (Wayland)\n"
         self.err_backend += "- hyprpaper (Wayland)\n- feh (Xorg)\n"
-        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n- gslapper (Xorg & Wayland)\n\n"
+        self.err_backend += "- wallutils (Xorg & Wayland)\n- mpvpaper (Xorg & Wayland)\n\n"
         self.err_backend += self.msg_info
 
         self.tip_refresh = "Recréer le dossier d'images"
@@ -210,7 +210,7 @@ class French:
         self.tip_random = "Définir un papier peint aléatoire"
         self.tip_exit = "Quitter l'application"
         self.tip_transition = "Choisissez le type de transition"
-        self.tip_mpv_stop = "Arrêter tous les processus mpv/gstreamer"
+        self.tip_mpv_stop = "Arrêter tous les processus mpv"
         self.tip_mpv_pause = "Pause du fond d'écran vidéo"
         self.tip_mpv_sound = "Lire le son de la vidéo"
         self.tip_timer = "Fréquence de changement automatique du fond d’écran"
@@ -281,7 +281,7 @@ class Polish:
         self.tip_random = "Ustaw losową tapetę"
         self.tip_exit = "Wyjdź z aplikacji"
         self.tip_transition = "Ustaw sposób przejścia"
-        self.tip_mpv_stop = "Zatrzymaj wszystkie procesy mpv/gstreamer"
+        self.tip_mpv_stop = "Zatrzymaj wszystkie procesy mpv"
         self.tip_mpv_pause = "Odtwarzaj/Zatrzymaj animowaną"
         self.tip_mpv_sound = "Odtwórz dźwięk z wideo"
         self.tip_timer = "Jak często automatycznie zmieniać tapetę"
@@ -351,7 +351,7 @@ class Russian:
         self.tip_random = "Установить случайные обои"
         self.tip_exit = "Выйти из приложения"
         self.tip_transition =  "Выберите тип перехода"
-        self.tip_mpv_stop = "Остановить все mpv/gstreamer процессы"
+        self.tip_mpv_stop = "Остановить все mpv процессы"
         self.tip_mpv_pause = "Плей/пауза видео-обоев"
         self.tip_mpv_sound = "Проигрывать звук видео-обоев"
         self.tip_timer = "Как часто автоматически менять обои"
@@ -422,7 +422,7 @@ class Belarusian:
         self.tip_random = "Усталяваць выпадковыя шпалеры"
         self.tip_exit = "Выйсці з прыкладання"
         self.tip_transition = "Выберыце тып пераходу"
-        self.tip_mpv_stop = "Спыніць усе працэсы mpv/gstreamer"
+        self.tip_mpv_stop = "Спыніць усе працэсы mpv"
         self.tip_mpv_pause = "Паўза відэа-абояў"
         self.tip_mpv_sound = "Прайграваць гук відэа"
         self.tip_timer = "Як часта аўтаматычна змяняць шпалеры"
@@ -493,7 +493,7 @@ class Chinese:
         self.tip_random = "设置随机壁纸"
         self.tip_exit = "退出应用程序"
         self.tip_transition = "选择过渡类型"
-        self.tip_mpv_stop = "停止所有 mpv/gstreamer 进程"
+        self.tip_mpv_stop = "停止所有 mpv 进程"
         self.tip_mpv_pause = "暂停视频壁纸"
         self.tip_mpv_sound = "播放视频的声音"
         self.tip_timer = "自动更换壁纸的频率"
@@ -563,7 +563,7 @@ class TraditionalChinese:
         self.tip_random = "隨機壁紙"
         self.tip_exit = "退出程式"
         self.tip_transition = "選擇過渡方式"
-        self.tip_mpv_stop = "暫停所有 mpv/gstreamer 程序"
+        self.tip_mpv_stop = "暫停所有 mpv 程序"
         self.tip_mpv_pause = "開始/暫停影片壁紙播放"
         self.tip_mpv_sound = "播放影片聲音"
         self.tip_timer = "自動選擇壁紙的時間"
@@ -634,7 +634,7 @@ class Spanish:
         self.tip_random = "Actualizar la imagen de fondo a una imagen aleatoria"
         self.tip_exit = "Cerrar la aplicación"
         self.tip_transition = "Elige el tipo de transición"
-        self.tip_mpv_stop = "Detener todos los procesos de mpv/gstreamer"
+        self.tip_mpv_stop = "Detener todos los procesos de mpv"
         self.tip_mpv_pause = "Pausar fondo de pantalla de video"
         self.tip_mpv_sound = "Reproducir el sonido del video"
         self.tip_timer = "Frecuencia con la que se cambia automáticamente el fondo de pantalla"
@@ -704,7 +704,7 @@ class Turkish:
         self.tip_random = "Rastgele bir duvar kağıdı ayarla"
         self.tip_exit = "Uygulamadan çık"
         self.tip_transition = "Geçiş türünü seç"
-        self.tip_mpv_stop = "Tüm mpv/gstreamer işlemlerini durdur"
+        self.tip_mpv_stop = "Tüm mpv işlemlerini durdur"
         self.tip_mpv_pause = "Video duvar kağıdını oynat/duraklat"
         self.tip_mpv_sound = "Videonun sesini oynat"
         self.tip_timer = "Duvar kağıdını ne sıklıkla otomatik değiştirileceğini belirle"
@@ -784,7 +784,7 @@ class Japanese:
         self.tip_random = "ランダムに壁紙を設定"
         self.tip_exit = "アプリケーションを終了"
         self.tip_transition = "切り替えタイプを選択"
-        self.tip_mpv_stop = "すべての mpv/gstreamer プロセスを停止"
+        self.tip_mpv_stop = "すべての mpv プロセスを停止"
         self.tip_mpv_pause = "動画壁紙を再生/一時停止"
         self.tip_mpv_sound = "動画の音声を再生"
         self.tip_timer = "自動で壁紙を変更する間隔"


### PR DESCRIPTION
PR adds support for gSlapper https://github.com/Nomadcxx/gSlapper as a new wallpaper backend. gSlapper is a drop-in replacement for mpvpaper (but better performance / resource use overall since it uses gstreamer instead of libmpv) so adding it as a backend was pretty straightforward. 

### Changes:

• Add gSlapper to backend options list
• Implement gSlapper support following mpvpaper implementation pattern
• Update UI to show mpv options for gSlapper (hide pause button since not supported)
• Update translations to include gSlapper backend
• Add gSlapper to image extensions (same as mpvpaper)
• Update process management to handle gSlapper processes
• Update README to document gSlapper support

## Testing:

• gSlapper appears in backend dropdown
•  video wallpapers work correctly with gSlapper
• "Stop all" functionality works with gSlapper
• pause button is hidden for gSlapper (since not supported)