### PR TITLE
Fix OSError not being caught when config file is read-only

### DIFF
--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -256,7 +256,7 @@ class Config:
         try:
             with open(self.config_file, "w") as configfile:
                 config.write(configfile)
-        except PermissionError:
+        except (PermissionError, OSError):
             print("Could not save config file due to permission error.")
 
         # If requested, save the state file:


### PR DESCRIPTION
The `use_xdg_state` option is intended to help preserve functionality such as saving the current wallpaper and directory when the main `config.ini` file is read-only. On certain systems (like those running NixOS), however, this functionality is broken because the following error is returned:

`OSError: [Errno 30] Read-only file system: '/home/user/.config/waypaper/config.ini'`

This is not caught by the `except PermissionError` statement, so the `save` method exits prematurely without ever getting the chance to call `save_state_file` and record the user's changes.

This PR adds `OSError` to the `except` statement to ensure the code can continue and save the state successfully.