### PR TITLE
Run awww/swww synchronously

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -222,7 +222,7 @@ def change_with_swww(image_path: Path, cf: Config, monitor: str):
     command.extend(["--transition-fps", str(cf.swww_transition_fps)])
     if monitor != "All":
         command.extend(["--outputs", monitor])
-    subprocess.Popen(command)
+    subprocess.run(command)
 
 def change_with_awww(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with awww backend"""
@@ -266,7 +266,7 @@ def change_with_awww(image_path: Path, cf: Config, monitor: str):
     command.extend(["--transition-fps", str(cf.swww_transition_fps)])
     if monitor != "All":
         command.extend(["--outputs", monitor])
-    subprocess.Popen(command)
+    subprocess.run(command)
 
 def change_with_feh(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with feh backend"""


### PR DESCRIPTION
This PR updates the changer code so that it waits for swww/awww to quit before proceeding, and in the end exiting.

The motivation behind this is that, while running those commands asynchronously on the terminal is fine, when running waypaper as a service as specified in the [documentation](https://anufrievroman.gitbook.io/waypaper/usage#cron-job), the wallpaper is actually never updated. The reason being that waypaper does not wait for the command to finish and stop. Systemd, seeing that the main process has stopped, immediately kills all the subprocesses, and that includes swww/awww, before it had the chance to apply the wallpaper change. The suggested [addition](https://github.com/anufrievroman/waypaper/issues/69#issuecomment-2871552596) of `KillMode=process` is not entirely satisfactory as it is not [recommended by systemd](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html#KillMode=) itself, and the need to asynchronously call the swww/awww command was not explicit. Is it an absolute requirement for some use case?

This PR focuses on awww/swww only as I'm not using any other backend, so can't test them. I'm guessing it would be required for swaybg though as it had reset the wallpaper to a gray background when I was looking for the culprit. But I haven't tested the change with it.

I can confirm that this change is required for swww and works with commit b8fd937bb82878a441c3880cf951b511c8e4abaf.