### PR TITLE
Fix hyprpaper functionality for newer versions

### DIFF
--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -352,6 +352,10 @@ def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):
             try:
                 subprocess.check_output(unload_command, encoding="utf-8").strip()
                 subprocess.check_output(preload_command, encoding="utf-8").strip()
+            except Exception:
+                # Preloading images with Hyprpaper is currently unavailable due to https://github.com/hyprwm/hyprpaper/pull/288
+                # It has not yet been determined if this will be reimplemented - https://github.com/hyprwm/hyprpaper/issues/292
+            try:
                 result = subprocess.check_output(wallpaper_command, encoding="utf-8").strip()
                 time.sleep(0.1)
             except Exception:


### PR DESCRIPTION
A [recent merge](https://github.com/hyprwm/hyprpaper/pull/288) into the main branch of Hyprpaper removed its image preloading/unloading capabilities.

There has not yet been a release of Hyprpaper since these changes were implemented, but the documentation has been updated. [This issue](https://github.com/hyprwm/hyprpaper/issues/292) asks for it to be reimplemented, but has not yet received a response.

This means that support for hyprpaper in Waypaper is still working for people using the release packages but is broken for those using the development packages

This PR simply moves those IPC requests to their own try/catch block so that the wallpaper will still be changed if they fail. This will not break functionality for users of existing releases of hyprpaper AND it will fix functionality for users of hyprpaper-git and in later versions of hyprpaper.