### PR TITLE
Fix monitor selection state mismatch on startup

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -345,6 +345,9 @@ class App(Gtk.Window):
             self.monitor_option_combo.set_active(monitor_names.index(self.cf.monitors[-1]))
         else:
             self.monitor_option_combo.set_active(0)
+
+        self.cf.selected_monitor = self.monitor_option_combo.get_active_text()
+
         self.monitor_option_combo.connect("changed", self.on_monitor_option_changed)
         self.monitor_option_combo.set_tooltip_text(self.txt.tip_display)
 


### PR DESCRIPTION
When the application starts, the monitor dropdown is visually set to the last used monitor, but the internal configuration state (`self.cf.selected_monitor`) remains at the default ("All"). This causes the application to apply wallpapers to all monitors instead of the visually selected one until the user manually changes the selection.

This commit updates `self.cf.selected_monitor` immediately after setting the initial value of the monitor dropdown to ensure the internal state matches the UI.