### PR TITLE
Add JSON backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GUI wallpaper setter for Wayland and Xorg window managers. It works as a fronten
 - Vim keys
 - Supports GIF animations (with `awww` or `mpvpaper`)
 - Supports videos (with `mpvpaper`)
+- Supports JSON backend (allows you to use waypaper to become a fancy image picker)
 - Supports multiple monitors (with `awww` or `swaybg` or `hyprpaper` or `mpvpaper`)
 - Works on Wayland (with `awww` or `swaybg` or `hyprpaper` or `wallutils` or `mpvpaper`)
 - Works on Xorg (with `feh`, `xwallpaper` or `wallutils`)
@@ -53,7 +54,7 @@ Waypaper is available in an external repository owned by Solopasha. You can add 
 
 ### Dependencies
 
-- `awww` or `swaybg` or `xwallpaper` or `feh` or `wallutils` or `hyprpaper` or `mpvpaper`
+- `awww` or `swaybg` or `xwallpaper` or `feh` or `wallutils` or `hyprpaper` or `mpvpaper` or `jq`
 - gobject python library (it might be called `python-gobject` or `python3-gi` or `python3-gobject` in your package manager.)
 - `python-imageio`
 - `python-imageio-ffmpeg`

--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -13,6 +13,7 @@ from waypaper.changer import change_wallpaper
 from waypaper.common import get_random_file
 from waypaper.config import Config
 from waypaper.options import BACKEND_OPTIONS, FILL_OPTIONS, get_monitor_options
+from waypaper.output import display_error, display_info
 from waypaper.translations import load_language
 
 
@@ -70,7 +71,7 @@ def run():
             if wallpaper_str:
                 wallpaper = pathlib.Path(wallpaper_str)
             else:
-                print("Could not get random wallpaper.")
+                display_error("Could not get random wallpaper.")
                 sys.exit(0)
 
         # Launch commands to change wallpaper in a separate thread:
@@ -130,12 +131,12 @@ def run():
     # Output some information in json format:
     if args.list:
         info = list(map(lambda x: {"monitor": x[0], "wallpaper": str(x[1]), "backend": cf.backend}, zip(cf.monitors, cf.wallpapers)))
-        print(json.dumps(info))
+        display_info(json.dumps(info))
         sys.exit(0)
 
     # Print the version and quit:
     if args.version:
-        print(f"waypaper v.{__version__}")
+        display_info(f"waypaper v.{__version__}")
         sys.exit(0)
 
     # Start GUI:

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -13,6 +13,7 @@ from waypaper.changer import change_wallpaper
 from waypaper.config import Config
 from waypaper.common import get_image_paths, get_image_name, get_random_file, cache_image, get_cached_image_path
 from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS , SWWW_TRANSITION_TYPES, get_monitor_options
+from waypaper.output import display_error
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 from waypaper.keybindings import Keys
 
@@ -656,7 +657,7 @@ class App(Gtk.Window):
                 try:
                     change_with_gslapper(Path(self.cf.selected_wallpaper), self.cf, self.cf.selected_monitor)
                 except Exception as e:
-                    print(f"Could not restart gSlapper with new audio setting: {e}")
+                    display_error(f"Could not restart gSlapper with new audio setting: {e}")
 
 
     def on_include_subfolders_toggled(self, toggle) -> None:
@@ -734,7 +735,7 @@ class App(Gtk.Window):
         """Update the active transition type based on the selected option"""
         active_index = combo.get_active()
         self.cf.swww_transition_type = SWWW_TRANSITION_TYPES[active_index]
-        print(f"Transition type changed to: {self.cf.swww_transition_type}")
+        display_info(f"Transition type changed to: {self.cf.swww_transition_type}")
 
 
     def on_color_set(self, color_button):
@@ -769,7 +770,7 @@ class App(Gtk.Window):
                 subprocess.run(waypaper_restore_command, encoding="utf-8")
                 # Problem: Hyprland uses default wallpaper after restart
             except Exception as e:
-                print(f"Exception: {e}")
+                display_error(f"Exception: {e}")
 
     def on_mpv_stop_button_clicked(self, widget) -> None:
         """On clicking mpv stop button, kill the mpvpaper or gslapper"""
@@ -784,7 +785,7 @@ class App(Gtk.Window):
             subprocess.Popen(f"echo 'cycle pause' | socat - /tmp/mpv-socket-{self.cf.selected_monitor}", shell=True)
         elif self.cf.backend == "gslapper":
             # gSlapper doesn't support pause, so do nothing or show message
-            print("Pause not supported for gSlapper")
+            display_error("Pause not supported for gSlapper")
 
     def on_random_clicked(self, widget) -> None:
         """On clicking random button, set random wallpaper"""
@@ -815,7 +816,7 @@ class App(Gtk.Window):
             shutil.rmtree(self.cf.cache_dir)
             os.makedirs(self.cf.cache_dir)
         except OSError as e:
-            print(f"{self.txt.err_cache} '{self.cf.cache_dir}': {e}")
+            display_error(f"{self.txt.err_cache} '{self.cf.cache_dir}': {e}")
         threading.Thread(target=self.process_images).start()
 
 

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -321,15 +321,16 @@ def change_with_finder(image_path: Path, cf: Config, monitor: str):
     subprocess.Popen(command, shell=True)
 
 def change_with_json(image_path: Path, cf: Config, monitor: str):
-    """Change wallpaper on macOS"""
+    """Output the wallpaper change command to stdout as json"""
+
     structure = {
         "image": str(image_path),
         "monitor": monitor,
         "fill": cf.fill_option.lower(),
+        "color": cf.color,
     }
 
     json_data = json.dumps(structure)
-
 
     p = subprocess.Popen(
         ["jq", "."],
@@ -339,7 +340,6 @@ def change_with_json(image_path: Path, cf: Config, monitor: str):
 
     output, _ = p.communicate(json_data.encode())
     display_info(output.decode(), only_tty=False)
-
 
 
 def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -1,5 +1,5 @@
 """Module that runs the system processes to change the wallpaper"""
-
+import json
 import subprocess
 import time
 from typing import Optional
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from waypaper.config import Config
 from waypaper.options import get_monitor_names_with_hyprctl
+from waypaper.output import display_info, display_error
 
 
 def find_process_pid(command: str) -> Optional[int]:
@@ -32,7 +33,7 @@ def seek_and_destroy(process: str, monitor: str = "All"):
             subprocess.check_output(["pgrep", f"{process}"], encoding='utf-8')
             subprocess.Popen(["killall", f"{process}"])
             time.sleep(0.1)
-            print(f"Killed all previous instances of {process}")
+            display_info(f"Killed all previous instances of {process}")
         except subprocess.CalledProcessError:
             pass
 
@@ -60,7 +61,7 @@ def seek_and_destroy(process: str, monitor: str = "All"):
             return
         try:
             subprocess.run(['kill', '-9', str(pid)], check=True)
-            print(f"Detected {process} on {monitor} and killed it")
+            display_info(f"Detected {process} on {monitor} and killed it")
         except Exception as e:
             pass
 
@@ -105,12 +106,12 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
     try:
         subprocess.check_output(["pgrep", "-f", f"socket-{monitor}"], encoding='utf-8')
         time.sleep(0.2)
-        print(f"Detected running mpvpaper on {monitor}, now trying to call mpvpaper socket")
+        display_info(f"Detected running mpvpaper on {monitor}, now trying to call mpvpaper socket")
         subprocess.Popen(f"echo 'loadfile \"{image_path}\"' | socat - /tmp/mpv-socket-{monitor}", shell=True)
 
     # If mpvpaper is not running, create a new process in a new socket:
     except subprocess.CalledProcessError:
-        print("Detected no running mpvpaper, starting new mpvpaper process")
+        display_info("Detected no running mpvpaper, starting new mpvpaper process")
         command = ["mpvpaper", "--fork"]
         if cf.mpvpaper_sound:
             command.extend(["-o", f"input-ipc-server=/tmp/mpv-socket-{monitor} {cf.mpvpaper_options} loop {fill} --background-color='{cf.color}'"])
@@ -125,7 +126,7 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
 
         command.extend([image_path])
 
-        print(f"{command=}")
+        display_info(f"{command=}")
         subprocess.Popen(command)
 
 
@@ -143,7 +144,7 @@ def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
     
     # Get the gSlapper option for current fill setting:
     gslapper_fill = fill_options.get(cf.fill_option.lower(), "panscan=1.0")
-    print(f"gSlapper fill option: {cf.fill_option} -> {gslapper_fill}")
+    display_info(f"gSlapper fill option: {cf.fill_option} -> {gslapper_fill}")
 
     # Kill any existing gSlapper process for this monitor:
     seek_and_destroy("gslapper", monitor)
@@ -176,7 +177,7 @@ def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
     # Add the image/video path:
     command.append(str(image_path))
     
-    print(f"gSlapper command: {command}")
+    display_info(f"gSlapper command: {command}")
     subprocess.Popen(command)
 
 
@@ -203,7 +204,7 @@ def change_with_swww(image_path: Path, cf: Config, monitor: str):
         subprocess.check_output(["pgrep", "swww-daemon"], encoding='utf-8')
     except subprocess.CalledProcessError:
         subprocess.Popen(["swww-daemon"])
-        print("Launched swww-daemon")
+        display_info("Launched swww-daemon")
 
     # Get rid of this in future when swww updates everywhere:
     version_p = subprocess.run(["swww", "-V"], capture_output=True, text=True)
@@ -247,7 +248,7 @@ def change_with_awww(image_path: Path, cf: Config, monitor: str):
         subprocess.check_output(["pgrep", "awww-daemon"], encoding='utf-8')
     except subprocess.CalledProcessError:
         subprocess.Popen(["awww-daemon"])
-        print("Launched awww-daemon")
+        display_info("Launched awww-daemon")
 
     # Get rid of this in future when swww updates everywhere:
     version_p = subprocess.run(["awww", "-V"], capture_output=True, text=True)
@@ -319,6 +320,27 @@ def change_with_finder(image_path: Path, cf: Config, monitor: str):
     command = f"osascript -e 'tell application \"Finder\" to set desktop picture to POSIX file \"{image_path}\"'"
     subprocess.Popen(command, shell=True)
 
+def change_with_json(image_path: Path, cf: Config, monitor: str):
+    """Change wallpaper on macOS"""
+    structure = {
+        "image": str(image_path),
+        "monitor": monitor,
+        "fill": cf.fill_option.lower(),
+    }
+
+    json_data = json.dumps(structure)
+
+
+    p = subprocess.Popen(
+        ["jq", "."],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE
+    )
+
+    output, _ = p.communicate(json_data.encode())
+    display_info(output.decode(), only_tty=False)
+
+
 
 def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with hyprpaper backend"""
@@ -374,9 +396,11 @@ def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):
 def change_wallpaper(image_path: Path, cf: Config, monitor: str):
     """Run system commands to change the wallpaper depending on the backend"""
 
-    print(f"Selected file: {image_path}")
+    display_info(f"Selected file: {image_path}")
 
     try:
+
+
         if cf.backend == "swaybg":
             change_with_swaybg(image_path, cf, monitor)
         if cf.backend == "mpvpaper":
@@ -397,9 +421,11 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
             change_with_gslapper(image_path, cf, monitor)
         if cf.backend == "macos":
             change_with_finder(image_path, cf, monitor)
+        if cf.backend == "json":
+            change_with_json(image_path, cf, monitor)
         if cf.backend != "none":
             filename = Path(image_path).resolve().name
-            print(f"Sent {cf.backend} command to set {filename} on {monitor} display\n")
+            display_info(f"Sent {cf.backend} command to set {filename} on {monitor} display\n")
 
         # Run a post command:
         if cf.post_command and cf.use_post_command:
@@ -407,7 +433,7 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
             post_command = cf.post_command.replace("$wallpaper", modified_image_path)
             post_command = post_command.replace("$monitor", monitor)
             subprocess.Popen(post_command, shell=True)
-            print(f'Executed "{post_command}" post-command\n')
+            display_info(f'Executed "{post_command}" post-command\n')
 
     except Exception as e:
-        print(f"Error occured while changing wallpaper: \n{e}")
+        display_error(f"Error occured while changing wallpaper: \n{e}")

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -3,17 +3,18 @@
 import os
 import gi
 import random
-import shutil
 import imageio
 import hashlib
 from pathlib import Path
 from typing import List
 from PIL import Image
 
+from waypaper.output import display_error
+
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib
 
-from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS, VIDEO_EXTENSIONS
+from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS, VIDEO_EXTENSIONS, get_installed_backends
 
 
 def has_image_extension(file_path: str, backend: str) -> bool:
@@ -118,26 +119,8 @@ def get_random_file(backend: str,
         return random_image
 
     except Exception as e:
-        print(f"Error getting random image: {e}")
+        display_error(f"Error getting random image: {e}")
         return None
-
-
-def check_installed_backends() -> List[str]:
-    """Check which backends are installed in the system"""
-    installed_backends = ["none"]
-    for backend in BACKEND_OPTIONS:
-        if backend == "none":
-            continue
-        elif backend == "wallutils":
-            binary_name = "setwallpaper"
-        elif backend == "macos":
-            binary_name = "sw_vers"
-        else:
-            binary_name = backend
-        is_installed = bool(shutil.which(binary_name))
-        if is_installed:
-            installed_backends.append(backend)
-    return installed_backends
 
 
 def get_cached_image_path(image_path: str, cache_dir: Path) -> Path:
@@ -182,8 +165,8 @@ def cache_image(image_path: str, cache_dir: Path) -> None:
 
     # If image processing failed, create a black placeholder:
     except Exception as e:
-        print(f"Could not generate preview for {os.path.basename(image_path)}")
-        print(e)
+        display_error(f"Could not generate preview for {os.path.basename(image_path)}")
+        display_error(e)
         black_pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, width, width*9/16)
         black_pixbuf.fill(0x0)
         black_pixbuf.savev(str(cache_file), "png", [], [])

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -7,7 +7,8 @@ from typing import List
 from platformdirs import user_config_path, user_pictures_path, user_cache_path, user_state_path
 
 from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SWWW_TRANSITION_TYPES, BACKEND_OPTIONS
-from waypaper.common import check_installed_backends
+from waypaper.common import get_installed_backends
+from waypaper.output import display_error
 
 
 class Config:
@@ -18,7 +19,7 @@ class Config:
         self.home_path = pathlib.Path.home()
         self.image_folder_list: list[pathlib.Path] = []
         self.image_folder_fallback: str = str(user_pictures_path())
-        self.installed_backends = check_installed_backends()
+        self.installed_backends = get_installed_backends()
         self.selected_wallpaper = None
         self.selected_monitor = "All"
         self.fill_option = FILL_OPTIONS[0]
@@ -200,7 +201,7 @@ class Config:
             with open(self.state_file, "w") as statefile:
                 state.write(statefile)
         except PermissionError:
-            print("Could not save state file due to permission error.")
+            display_error("Could not save state file due to permission error.")
 
 
     def write_folder_list_to_config(self, section: str, config):
@@ -257,7 +258,7 @@ class Config:
             with open(self.config_file, "w") as configfile:
                 config.write(configfile)
         except (PermissionError, OSError):
-            print("Could not save config file due to permission error.")
+            display_error("Could not save config file due to permission error.")
 
         # If requested, save the state file:
         if self.use_xdg_state:

--- a/waypaper/keybindings.py
+++ b/waypaper/keybindings.py
@@ -4,6 +4,7 @@ import gi
 import os
 import configparser
 from waypaper.config import Config
+from waypaper.output import display_warning
 
 gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk
@@ -38,7 +39,7 @@ class Keys:
             with open(path, 'r') as file:
                 pass
         except FileNotFoundError:
-            print(f"File '{path}' does not exist")
+            display_warning(f"File '{path}' does not exist")
             return
 
         # Parse the file:

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -1,16 +1,18 @@
 """Module that contains lists of possible options used in the application"""
 import json
 import subprocess
+import shutil
 
 from typing import List, Dict
 
+from waypaper.output import display_error, display_info
 
-BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "xwallpaper", "wallutils", "hyprpaper", "mpvpaper", "gslapper", "macos", "awww"]
+BACKEND_OPTIONS: List[str] = ["none", "swaybg", "swww", "feh", "xwallpaper", "wallutils", "hyprpaper", "mpvpaper", "gslapper", "macos", "awww",  "json"]
 FILL_OPTIONS: List[str] = ["fill", "stretch", "fit", "center", "tile"]
 SORT_OPTIONS: List[str] = ["name", "namerev", "date", "daterev", "random"]
 SORT_DISPLAYS: Dict[str, str] = {"name": "Name ↓", "namerev": "Name ↑", "date": "Date ↓", "daterev": "Date ↑", "random": "Random"}
 
-VIDEO_EXTENSIONS: List[str] = ['.webm', '.mkv', '.flv', '.vob', '.ogv', '.ogg', '.rrc', '.gifv', '.mng', '.mov',
+VIDEO_EXTENSIONS: List[str] = ['.webm', '.mkv', '.flv', '.vob', '.ogv', '.ogg', '.rrc', '.gifv', '.mng', '.movawww',
                                '.avi', '.qt', '.wmv', '.yuv', '.rm', '.asf', '.amv', '.mp4', '.m4p', '.m4v',
                                '.mpg', '.mp2', '.mpeg', '.mpe', '.mpv', '.m4v', '.svi', '.3gp', '.3g2', '.mxf',
                                '.roq', '.nsv', '.flv', '.f4v', '.f4p', '.f4a', '.f4b', '.mod' ]
@@ -27,6 +29,7 @@ IMAGE_EXTENSIONS: Dict[str, List[str]] = {
         BACKEND_OPTIONS[8]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff', '.avif'] + VIDEO_EXTENSIONS,
         BACKEND_OPTIONS[9]: ['.gif', '.jpg', '.jpeg', '.png'],
         BACKEND_OPTIONS[10]: ['.gif', '.jpg', '.jpeg', '.jxl', '.png', '.webp', '.bmp', '.pnm', '.tiff'],
+        BACKEND_OPTIONS[11]: ['.gif', '.jpg', '.jpeg', '.png', '.webp', '.bmp', '.pnm', '.tiff', '.avif'] + VIDEO_EXTENSIONS,
         }
 
 SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "left", "right", "top",
@@ -35,6 +38,24 @@ SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "l
 TIMERS: Dict[str, int] = {"30 sec": 30, "1 min": 60, "2 min": 120, "5 min": 300, "10 min": 600, "30 min": 1800, "1 hour": 3600,
           "2 hours": 7200, "6 hours": 21600, "12 hours": 43200, "1 day": 86400, "1 week": 604800}
 
+def get_installed_backends() -> List[str]:
+    """Check which backends are installed in the system"""
+    installed_backends = ["none"]
+    for backend in BACKEND_OPTIONS:
+        if backend == "none":
+            continue
+        elif backend == "wallutils":
+            binary_name = "setwallpaper"
+        elif backend == "macos":
+            binary_name = "sw_vers"
+        elif backend == "json":
+            binary_name = "jq"
+        else:
+            binary_name = backend
+        is_installed = bool(shutil.which(binary_name))
+        if is_installed:
+            installed_backends.append(backend)
+    return installed_backends
 
 def get_monitor_names_with_swww() -> List[str]:
     """Obtain the list of plugged monitors using swww daemon"""
@@ -45,7 +66,7 @@ def get_monitor_names_with_swww() -> List[str]:
             subprocess.check_output(["pgrep", "swww-daemon"], encoding='utf-8')
         except subprocess.CalledProcessError:
             subprocess.Popen(["swww-daemon"])
-            print("The swww-daemon launched.")
+            display_info("The swww-daemon launched.")
         # Check available monitors:
         monitors_info = str(subprocess.check_output(["swww", "query"], encoding='utf-8'))
         monitors = monitors_info.split("\n")
@@ -58,7 +79,7 @@ def get_monitor_names_with_swww() -> List[str]:
                 connected_monitors.append(monitor.split(':')[0])
 
     except Exception as e:
-        print(f"Exception: {e}")
+        display_error(f"Exception: {e}")
     return connected_monitors
 
 def get_monitor_names_with_awww() -> List[str]:
@@ -70,7 +91,7 @@ def get_monitor_names_with_awww() -> List[str]:
             subprocess.check_output(["pgrep", "awww-daemon"], encoding='utf-8')
         except subprocess.CalledProcessError:
             subprocess.Popen(["awww-daemon"])
-            print("The awww-daemon launched.")
+            display_info("The awww-daemon launched.")
         # Check available monitors:
         monitors_info = str(subprocess.check_output(["awww", "query"], encoding='utf-8'))
         monitors = monitors_info.split("\n")
@@ -83,7 +104,7 @@ def get_monitor_names_with_awww() -> List[str]:
                 connected_monitors.append(monitor.split(':')[0])
 
     except Exception as e:
-        print(f"Exception: {e}")
+        display_error(f"Exception: {e}")
     return connected_monitors
 
 def get_monitor_names_with_hyprctl() -> List[str]:
@@ -96,17 +117,33 @@ def get_monitors(backend) -> List[str]:
     """Get a list of monitor names by various means depending on the backend.
     Returns a list of monitor names or an empty list if an error occurs."""
     try:
-        if backend == "hyprpaper":
-            return get_monitor_names_with_hyprctl()
-        elif backend == "swww":
-            return get_monitor_names_with_swww()
-        elif backend == "awww":
-            return get_monitor_names_with_awww()
-        else:
-            from screeninfo import get_monitors as _get_monitors
-            return [m.name for m in _get_monitors()]
+
+        available_backends = get_installed_backends()
+
+        monitor_lookup_helpers = {
+            "hyprctl": get_monitor_names_with_hyprctl,
+            "awww": get_monitor_names_with_awww,
+            "swww": get_monitor_names_with_swww,
+        }
+
+        if backend == "json":
+            for identifier in monitor_lookup_helpers:
+                if identifier in monitor_lookup_helpers and identifier in available_backends:
+                    method = monitor_lookup_helpers[identifier]
+                    return method()
+
+        for identifier in monitor_lookup_helpers:
+            if backend == identifier:
+                method = monitor_lookup_helpers[backend]
+                return method()
+
+
+        from screeninfo import get_monitors as _get_monitors
+        return [m.name for m in _get_monitors()]
+
+
     except Exception as e:
-        print(f"Error fetching monitors: {e}. Falling back to 'All'.")
+        display_error(f"Error fetching monitors: {e}. Falling back to 'All'.")
         return []
 
 

--- a/waypaper/output.py
+++ b/waypaper/output.py
@@ -1,0 +1,19 @@
+import sys
+
+
+def display_info(message: str, only_tty = True):
+    """Display a message to stdout only if the output is not piped."""
+    if only_tty and not sys.stdout.isatty():
+        return
+
+    print(message, file=sys.stdout)
+
+
+def display_warning(message: str):
+    """Display a warning."""
+    display_info(message)
+
+
+def display_error(message: str):
+    """Output a message to stderr."""
+    print(message, file=sys.stderr)

--- a/waypaper/waypaperd.py
+++ b/waypaper/waypaperd.py
@@ -7,6 +7,9 @@ import time
 import os
 import argparse
 
+from waypaper.output import display_info, display_error
+
+
 def main():
     parser = argparse.ArgumentParser(description="Randomly changes wallpaper every specified number of seconds.")
     parser.add_argument("interval", type=int, help="Time interval in seconds until next wallpaper change.")
@@ -15,10 +18,10 @@ def main():
     try:
         while True:
             os.system("waypaper --random")
-            print(f"Command to change wallpaper executed. Waiting {args.interval} seconds.")
+            display_info(f"Command to change wallpaper executed. Waiting {args.interval} seconds.")
             time.sleep(args.interval)
     except KeyboardInterrupt:
-        print("Program interrupted. Exiting.")
+        display_error("Program interrupted. Exiting.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Add JSON Backend

I have written a JSON backend for the will allow for better usage in scripts. I will include a simple script i run my
self in hyprland to change my wallpaper. This backend will allow scripts to use waypaper as a general image picker.

PS: I hope i didnt break your "Please propose features separately, don't combine unrelated changes into one PR." rule. If this 
is the case please let me know.


Before:

```bash
#!/usr/bin/env bash

CACHE_FILE=/home/johnny/.cache/wallpaper.txt
WALLPAPER=$(waypaper --folder "$HOME/Documents/ultrawide" --backend none | awk -F": " '{print $2}')

echo "$WALLPAPER" > $CACHE_FILE

# This is here because my 2.7 version of waypaper
# does not see awww so the backend was not possible.
#
# Also i need this separate anyway because $CACHE_FILE
# will be read for pywall to change term colors.
awww img $WALLPAPER
```

New backend output:

Notice how there are no warnings or "selected file: " message because it will detect if it is on a user facing
terminal or not.

```bash
echo $(waypaper --folder "$HOME/Documents/ultrawide" --backend json)
{ "image": "/home/johnny/Documents/ultrawide/1hditmhjt4d71.png", "monitor": "DP-3", "fill": "fill" }
```

This allows me to update my script to:

```bash
#!/usr/bin/env bash

CACHE_FILE=/home/johnny/.cache/wallpaper.txt
WALLPAPER=$(waypaper --folder "$HOME/Documents/ultrawide" --backend json | jq -r .image)

rm $CACHE_FILE

echo "$WALLPAPER" > $CACHE_FILE

# This is here because my 2.7 version of waypaper
# does not see awww so the backend was not possible.
#
# Also i need this separate anyway because $CACHE_FILE
# will be read for pywall to change term colors.
awww img $WALLPAPER
```

common.py

- removed check_installed_backends and moved it to options.py as get_installed_backends. This rename makes it more
  generic
  and it feels better to use in get_monitors.
- removed import shutil
- replaced error prints with display_error()

options.py

- Added json to BACKEND_OPTIONS in config.py
- added get_installed_backends (was check_installed_backends in common.py
- added import shutil
- replaced success prints with display_info()
- replaced error prints with display_error()
- rewrote get_monitors so it could detect installed backends and use them to get the monitors when
  the backend is json.

changer.py

- added import json
- updated change_wallpaper to support json
- added function change_with_json

keybindings.py

- replaced print with display_error
- error "xx" now uses display_warning and will only be displayed on a tty
- config.py
- replaced error prints with display_error()

app.py

- replaced prints with display_info()
- replaced error prints with display_error()

README.md

- Added a few lines about the json backend

## output.py (new)

This file is new and has 3 new functions **display_info**, **display_warning** and **display_error**. These functions
are written to not only separate their types of output info/warning and error. But it **display_info** by default will
not print if the app is not running on a visible terminal, this is ideal if you have a backend of type JSON where
you want to get the selected image.

Open questions:
The json output depends on jq now and is only available if installed. This is done so it would have a pretty print
but we could additionally just output flat json as well.