### PR TITLE
Change GTK CSS provider priority to user level

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -68,7 +68,7 @@ class App(Gtk.Window):
         # Apply CSS to the default screen
         screen = Gdk.Screen.get_default()
         context = Gtk.StyleContext()
-        context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
         # TOP MENU
 


### PR DESCRIPTION
From #268 

## Detail

When a user has a `window { background-color: ... }` rule in `~/.config/gtk-3.0/gtk.css`, the background color set in waypaper's custom stylesheet has no effect, even though other CSS properties (e.g. button styles) work correctly.

## Fix

Changed the CSS provider priority from `PRIORITY_APPLICATION` to `PRIORITY_USER` when registering the user stylesheet:

```python
# Before
context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)

# After
context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
```

This matches GTK3's own priority for `~/.config/gtk-3.0/gtk.css`, so waypaper's user stylesheet can now properly override any conflicting rules from the GTK theme or user GTK config.