### PR TITLE
Update README.md fedora install

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Users of OpenSUSE [reported issue with installation](https://github.com/anufriev
 
 #### On Fedora
 
-Waypaper is available in an external repository owned by Solopasha. You can add this repository as `sudo dnf copr enable solopasha/hyprland` and install as `sudo dnf install waypaper`.
+Waypaper is available in an external repository owned by Solopasha. You can add this repository as `sudo dnf copr enable lionheartp/Hyprland` and install as `sudo dnf install waypaper`.
 
 ### Dependencies
 


### PR DESCRIPTION
solopasha does not really maintain the hyprland copr anymore, so lionheartp/Hyprland is now more up-to-date.