### PR TITLE
Surface Wallpaper Engine project type in the UI

### DIFF
--- a/tests/test_wallpaperengine.py
+++ b/tests/test_wallpaperengine.py
@@ -1,0 +1,114 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from waypaper.common import get_image_name
+from waypaper.wallpaperengine import (
+    get_wallpaperengine_image_name,
+    get_wallpaperengine_preview,
+    get_wallpaperengine_project,
+    get_wallpaperengine_project_dir,
+)
+
+
+class WallpaperEngineMetadataTest(unittest.TestCase):
+    def test_project_dir_accepts_directory_or_child_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            preview_path = project_dir / "preview.jpg"
+
+            self.assertEqual(get_wallpaperengine_project_dir(project_dir), project_dir)
+            self.assertEqual(get_wallpaperengine_project_dir(preview_path), project_dir)
+
+    def test_project_metadata_normalizes_type_and_title(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            (project_dir / "project.json").write_text(json.dumps({"type": " Video "}), encoding="utf-8")
+
+            project = get_wallpaperengine_project(project_dir / "preview.jpg")
+
+            self.assertEqual(project["type"], "video")
+            self.assertEqual(project["title"], project_dir.name)
+
+    def test_image_name_labels_known_project_types(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            (project_dir / "project.json").write_text(json.dumps({"type": "scene", "title": "Neon Driver"}), encoding="utf-8")
+
+            self.assertEqual(get_wallpaperengine_image_name(project_dir / "preview.jpg"), "Neon Driver [scene]")
+
+    def test_image_name_marks_unknown_project_types(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            (project_dir / "project.json").write_text(json.dumps({"type": "preset", "title": "Visualizer"}), encoding="utf-8")
+
+            self.assertEqual(get_wallpaperengine_image_name(project_dir / "preview.jpg"), "Visualizer [preset ?]")
+
+    def test_image_name_falls_back_to_directory_name_on_bad_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            (project_dir / "project.json").write_text("{", encoding="utf-8")
+
+            self.assertEqual(get_wallpaperengine_image_name(project_dir / "preview.jpg"), project_dir.name)
+
+    def test_preview_search_returns_preview_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            nested_dir = project_dir / "nested"
+            nested_dir.mkdir()
+            preview_path = nested_dir / "preview.jpg"
+            preview_path.touch()
+            (nested_dir / "not-preview.jpg").touch()
+
+            self.assertEqual(get_wallpaperengine_preview(project_dir), [str(preview_path)])
+
+
+class GetImageNameTest(unittest.TestCase):
+    """Verify common.get_image_name surfaces WE project.json title [type]."""
+
+    def test_get_image_name_uses_project_json_title_for_workshop_paths(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_folder = Path(tmpdir) / "Wallpapers"
+            project_dir = base_folder / "431960" / "12345"
+            project_dir.mkdir(parents=True)
+            preview = project_dir / "preview.jpg"
+            preview.touch()
+            (project_dir / "project.json").write_text(
+                json.dumps({"type": "scene", "title": "Neon Driver"}),
+                encoding="utf-8",
+            )
+
+            name = get_image_name(str(preview), [base_folder], include_path=False)
+
+            self.assertEqual(name, "Neon Driver [scene]")
+
+    def test_get_image_name_falls_back_to_path_name_when_project_json_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_folder = Path(tmpdir) / "Wallpapers"
+            project_dir = base_folder / "431960" / "12345"
+            project_dir.mkdir(parents=True)
+            preview = project_dir / "preview.jpg"
+            preview.touch()
+            # no project.json in the parent
+
+            name = get_image_name(str(preview), [base_folder], include_path=False)
+
+            self.assertEqual(name, "preview.jpg")
+
+    def test_get_image_name_falls_back_to_path_name_when_project_json_malformed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_folder = Path(tmpdir) / "Wallpapers"
+            project_dir = base_folder / "431960" / "12345"
+            project_dir.mkdir(parents=True)
+            preview = project_dir / "preview.jpg"
+            preview.touch()
+            (project_dir / "project.json").write_text("{", encoding="utf-8")
+
+            name = get_image_name(str(preview), [base_folder], include_path=False)
+
+            self.assertEqual(name, "preview.jpg")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -12,12 +12,15 @@ import hashlib
 from pathlib import Path
 from typing import List
 from PIL import Image
-import json
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib
 
 from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS, VIDEO_EXTENSIONS
+from waypaper.wallpaperengine import (
+    get_wallpaperengine_image_name,
+    get_wallpaperengine_preview,
+)
 
 
 def has_image_extension(file_path: str, backend: str) -> bool:
@@ -65,25 +68,24 @@ def get_image_paths(backend: str,
                 image_path_list.append(os.path.join(root, image_name))
     return image_path_list
 
-def get_wallpaperengine_preview(wallpaperengine_folder: Path | str) -> List[str]:
-    image_path_list = []
-    for root, directories, files in os.walk(wallpaperengine_folder):
-        for file in files:
-            if Path(file).stem == "preview":
-                image_path_list.append(os.path.join(root, file))
-    return image_path_list
-
-def get_wallpaperengine_image_name(full_path: Path | str) -> str:
-    full_path = Path(full_path)
-    image_dir = full_path.parent
-    with open(image_dir / "project.json", "r") as f:
-        project = json.load(f)
-    return project["title"]
-
-
 def get_image_name(full_path: str, base_folder_list: list[Path], include_path: bool) ->  str | None:
-    """Get image name that may or may not include parent folders"""
+    """Get image name that may or may not include parent folders
+
+    For Wallpaper Engine projects (paths that sit next to a ``project.json``
+    file), the tooltip shows the normalized ``Title [type]`` from
+    ``project.json`` instead of the raw path. The Workshop project
+    directory layout makes this cheap to detect without an extra walk.
+    Malformed or missing ``project.json`` falls through to the regular
+    path-based name so the grid never shows an empty tooltip.
+    """
     full_path = Path(os.path.normpath(full_path)).absolute()
+
+    # Workshop projects: surface the normalized title [type] in the tooltip.
+    if (full_path.parent / "project.json").exists():
+        try:
+            return get_wallpaperengine_image_name(full_path)
+        except Exception:
+            pass  # fall through to the regular path-based name
 
     # If path is not required, just return file name:
     if not include_path:

--- a/waypaper/wallpaperengine.py
+++ b/waypaper/wallpaperengine.py
@@ -1,0 +1,41 @@
+"""Wallpaper Engine project helpers."""
+
+import json
+import os
+from pathlib import Path
+from typing import List
+
+
+def get_wallpaperengine_preview(wallpaperengine_folder: Path | str) -> List[str]:
+    image_path_list = []
+    for root, directories, files in os.walk(wallpaperengine_folder):
+        for file in files:
+            if Path(file).stem == "preview":
+                image_path_list.append(os.path.join(root, file))
+    return image_path_list
+
+
+def get_wallpaperengine_project_dir(full_path: Path | str) -> Path:
+    full_path = Path(full_path)
+    return full_path if full_path.is_dir() else full_path.parent
+
+
+def get_wallpaperengine_project(full_path: Path | str) -> dict:
+    image_dir = get_wallpaperengine_project_dir(full_path)
+    with open(image_dir / "project.json", "r", encoding="utf-8") as file:
+        project = json.load(file)
+    wallpaper_type = str(project.get("type", "unknown")).strip().lower() or "unknown"
+    project["type"] = wallpaper_type
+    project["title"] = str(project.get("title") or image_dir.name)
+    return project
+
+
+def get_wallpaperengine_image_name(full_path: Path | str) -> str:
+    try:
+        project = get_wallpaperengine_project(full_path)
+        wallpaper_type = project["type"]
+        if wallpaper_type in {"scene", "video", "web"}:
+            return f"{project['title']} [{wallpaper_type}]"
+        return f"{project['title']} [{wallpaper_type} ?]"
+    except Exception:
+        return Path(full_path).parent.name


### PR DESCRIPTION
Closes #275

## Summary

Normalize Wallpaper Engine metadata from `project.json` and surface the detected project type directly in the UI so `scene`, `video`, and `web` entries stop looking like generic static previews.

## Architecture

This PR is standalone on top of `main`; it does not require #279 to be merged first.

To keep Wallpaper Engine-specific metadata out of the generic file/image helpers, this PR adds a small `waypaper/wallpaperengine.py` module for the UI metadata slice:

- preview discovery for Wallpaper Engine projects
- project directory normalization
- `project.json` loading and `type`/`title` normalization
- type-aware UI labels such as `Title [scene]`, `Title [video]`, and `Title [web]`
- defensive fallback to the project directory name if metadata cannot be read while rendering the grid

`waypaper/common.py` remains focused on generic file/image operations, and `waypaper/app.py` imports the Wallpaper Engine label helpers from the dedicated module.

If #279 or #280 lands first, the shared `wallpaperengine.py` module boundary can be reconciled through a normal rebase. This PR remains reviewable as the narrow UI metadata slice.

## Scope Boundary

- No backend routing changes here.
- No launcher hardening here.
- No renderer behavior changes here.
- This PR exists so later behavior decisions can rely on normalized metadata instead of preview filenames.

## Validation

- `python3 -m py_compile waypaper/app.py waypaper/common.py waypaper/wallpaperengine.py tests/test_wallpaperengine.py`
- `python3 -m unittest discover -s tests`
- `git diff --check origin/main...HEAD`

Current result: 17 tests pass.
