### PR TITLE
Harden linux-wallpaperengine launcher resolution and failure reporting

### DIFF
--- a/tests/test_linux_wallpaperengine_logging.py
+++ b/tests/test_linux_wallpaperengine_logging.py
@@ -1,0 +1,129 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from waypaper.changer import change_with_linux_wallpaperengine, describe_linux_wallpaperengine_pause_policy
+
+
+class LinuxWallpaperengineLoggingTests(unittest.TestCase):
+    def make_config(self, cache_dir: Path) -> SimpleNamespace:
+        return SimpleNamespace(
+            fill_option="fill",
+            linux_wallpaperengine_silent=True,
+            linux_wallpaperengine_noautomute=True,
+            linux_wallpaperengine_no_audio_processing=False,
+            linux_wallpaperengine_no_fullscreen_pause=False,
+            linux_wallpaperengine_fullscreen_pause_only_active=False,
+            linux_wallpaperengine_disable_particles=True,
+            linux_wallpaperengine_disable_mouse=False,
+            linux_wallpaperengine_disable_parallax=False,
+            linux_wallpaperengine_clamp="none",
+            linux_wallpaperengine_volume=15,
+            linux_wallpaperengine_fps=30,
+            cache_dir=cache_dir,
+        )
+
+    def test_describe_pause_policy_variants(self):
+        config = self.make_config(Path("/tmp"))
+        self.assertEqual(describe_linux_wallpaperengine_pause_policy(config), "renderer default")
+
+        config.linux_wallpaperengine_fullscreen_pause_only_active = True
+        self.assertIn("fullscreen-pause-only-active", describe_linux_wallpaperengine_pause_policy(config))
+
+        config.linux_wallpaperengine_no_fullscreen_pause = True
+        self.assertEqual(
+            describe_linux_wallpaperengine_pause_policy(config),
+            "disabled via --no-fullscreen-pause",
+        )
+
+    def test_scene_log_records_running_process_health(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = Path(tmp_dir)
+            wallpaper_dir = cache_dir / "scene-wallpaper"
+            wallpaper_dir.mkdir()
+            image_path = wallpaper_dir / "project.json"
+            image_path.write_text("{}", encoding="utf-8")
+            log_path = cache_dir / "launcher.log"
+            config = self.make_config(cache_dir)
+
+            process = MagicMock(pid=4242)
+            process.poll.return_value = None
+
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.get_wallpaperengine_project",
+                return_value={"title": "Test Scene", "type": "scene", "file": "scene.json"},
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                return_value="/usr/bin/linux-wallpaperengine",
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                return_value=Path("/assets"),
+            ), patch(
+                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                return_value=log_path,
+            ), patch(
+                "waypaper.changer.subprocess.Popen",
+                return_value=process,
+            ) as popen_mock, patch(
+                "waypaper.changer.time.sleep"
+            ), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ) as notify_mock:
+                change_with_linux_wallpaperengine(image_path, config, "DP-1")
+
+            command = popen_mock.call_args.args[0]
+            self.assertNotIn("--disable-particles", command)
+
+            log_text = log_path.read_text(encoding="utf-8")
+            self.assertIn("Launch PID: 4242", log_text)
+            self.assertIn("Process status after initial check: still running after 0.5s.", log_text)
+            self.assertIn("Fullscreen pause policy: renderer default", log_text)
+            notify_mock.assert_not_called()
+
+    def test_immediate_exit_is_recorded_in_log(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = Path(tmp_dir)
+            wallpaper_dir = cache_dir / "video-wallpaper"
+            wallpaper_dir.mkdir()
+            image_path = wallpaper_dir / "project.json"
+            image_path.write_text("{}", encoding="utf-8")
+            log_path = cache_dir / "launcher.log"
+            config = self.make_config(cache_dir)
+
+            process = MagicMock(pid=99)
+            process.poll.return_value = 7
+
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.get_wallpaperengine_project",
+                return_value={"title": "Test Video", "type": "video", "file": "video.mp4"},
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                return_value="/usr/bin/linux-wallpaperengine",
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                return_value=Path("/assets"),
+            ), patch(
+                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                return_value=log_path,
+            ), patch(
+                "waypaper.changer.subprocess.Popen",
+                return_value=process,
+            ), patch(
+                "waypaper.changer.time.sleep"
+            ), patch(
+                "waypaper.changer.change_with_static_fallback",
+                return_value="swaybg",
+            ), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ) as notify_mock:
+                change_with_linux_wallpaperengine(image_path, config, "DP-1")
+
+            log_text = log_path.read_text(encoding="utf-8")
+            self.assertIn("Process status after initial check: exited with code 7", log_text)
+            notify_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linux_wallpaperengine_logging.py
+++ b/tests/test_linux_wallpaperengine_logging.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from waypaper.changer import change_with_linux_wallpaperengine, describe_linux_wallpaperengine_pause_policy
+from waypaper.changer import change_with_linux_wallpaperengine
+from waypaper.wallpaperengine import describe_linux_wallpaperengine_pause_policy
 
 
 class LinuxWallpaperengineLoggingTests(unittest.TestCase):
@@ -52,24 +53,24 @@ class LinuxWallpaperengineLoggingTests(unittest.TestCase):
             process.poll.return_value = None
 
             with patch("waypaper.changer.seek_and_destroy"), patch(
-                "waypaper.changer.get_wallpaperengine_project",
+                "waypaper.wallpaperengine.get_wallpaperengine_project",
                 return_value={"title": "Test Scene", "type": "scene", "file": "scene.json"},
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_binary",
                 return_value="/usr/bin/linux-wallpaperengine",
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_assets_dir",
                 return_value=Path("/assets"),
             ), patch(
-                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                "waypaper.wallpaperengine.get_linux_wallpaperengine_log_path",
                 return_value=log_path,
             ), patch(
-                "waypaper.changer.subprocess.Popen",
+                "waypaper.wallpaperengine.subprocess.Popen",
                 return_value=process,
             ) as popen_mock, patch(
-                "waypaper.changer.time.sleep"
+                "waypaper.wallpaperengine.time.sleep"
             ), patch(
-                "waypaper.changer.notify_waypaper_issue"
+                "waypaper.wallpaperengine.notify_waypaper_issue"
             ) as notify_mock:
                 change_with_linux_wallpaperengine(image_path, config, "DP-1")
 
@@ -96,27 +97,27 @@ class LinuxWallpaperengineLoggingTests(unittest.TestCase):
             process.poll.return_value = 7
 
             with patch("waypaper.changer.seek_and_destroy"), patch(
-                "waypaper.changer.get_wallpaperengine_project",
+                "waypaper.wallpaperengine.get_wallpaperengine_project",
                 return_value={"title": "Test Video", "type": "video", "file": "video.mp4"},
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_binary",
                 return_value="/usr/bin/linux-wallpaperengine",
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_assets_dir",
                 return_value=Path("/assets"),
             ), patch(
-                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                "waypaper.wallpaperengine.get_linux_wallpaperengine_log_path",
                 return_value=log_path,
             ), patch(
-                "waypaper.changer.subprocess.Popen",
+                "waypaper.wallpaperengine.subprocess.Popen",
                 return_value=process,
             ), patch(
-                "waypaper.changer.time.sleep"
+                "waypaper.wallpaperengine.time.sleep"
             ), patch(
                 "waypaper.changer.change_with_static_fallback",
                 return_value="swaybg",
             ), patch(
-                "waypaper.changer.notify_waypaper_issue"
+                "waypaper.wallpaperengine.notify_waypaper_issue"
             ) as notify_mock:
                 change_with_linux_wallpaperengine(image_path, config, "DP-1")
 
@@ -138,29 +139,29 @@ class LinuxWallpaperengineLoggingTests(unittest.TestCase):
             process.poll.return_value = -9
 
             with patch("waypaper.changer.seek_and_destroy"), patch(
-                "waypaper.changer.get_wallpaperengine_project",
+                "waypaper.wallpaperengine.get_wallpaperengine_project",
                 return_value={"title": "Test Scene", "type": "scene", "file": "scene.json"},
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_binary",
                 return_value="/usr/bin/linux-wallpaperengine",
             ), patch(
-                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                "waypaper.wallpaperengine.resolve_linux_wallpaperengine_assets_dir",
                 return_value=Path("/assets"),
             ), patch(
-                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                "waypaper.wallpaperengine.get_linux_wallpaperengine_log_path",
                 return_value=log_path,
             ), patch(
-                "waypaper.changer.subprocess.Popen",
+                "waypaper.wallpaperengine.subprocess.Popen",
                 return_value=process,
             ), patch(
-                "waypaper.changer.time.sleep"
+                "waypaper.wallpaperengine.time.sleep"
             ), patch(
-                "waypaper.changer.find_replacement_linux_wallpaperengine_pid",
+                "waypaper.wallpaperengine.find_replacement_linux_wallpaperengine_pid",
                 return_value=777,
             ), patch(
                 "waypaper.changer.change_with_static_fallback"
             ) as fallback_mock, patch(
-                "waypaper.changer.notify_waypaper_issue"
+                "waypaper.wallpaperengine.notify_waypaper_issue"
             ) as notify_mock:
                 change_with_linux_wallpaperengine(image_path, config, "eDP-1")
 

--- a/tests/test_linux_wallpaperengine_logging.py
+++ b/tests/test_linux_wallpaperengine_logging.py
@@ -124,6 +124,51 @@ class LinuxWallpaperengineLoggingTests(unittest.TestCase):
             self.assertIn("Process status after initial check: exited with code 7", log_text)
             notify_mock.assert_called_once()
 
+    def test_sigkill_is_suppressed_when_replaced_by_newer_process(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = Path(tmp_dir)
+            wallpaper_dir = cache_dir / "scene-wallpaper"
+            wallpaper_dir.mkdir()
+            image_path = wallpaper_dir / "project.json"
+            image_path.write_text("{}", encoding="utf-8")
+            log_path = cache_dir / "launcher.log"
+            config = self.make_config(cache_dir)
+
+            process = MagicMock(pid=555)
+            process.poll.return_value = -9
+
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.get_wallpaperengine_project",
+                return_value={"title": "Test Scene", "type": "scene", "file": "scene.json"},
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_binary",
+                return_value="/usr/bin/linux-wallpaperengine",
+            ), patch(
+                "waypaper.changer.resolve_linux_wallpaperengine_assets_dir",
+                return_value=Path("/assets"),
+            ), patch(
+                "waypaper.changer.get_linux_wallpaperengine_log_path",
+                return_value=log_path,
+            ), patch(
+                "waypaper.changer.subprocess.Popen",
+                return_value=process,
+            ), patch(
+                "waypaper.changer.time.sleep"
+            ), patch(
+                "waypaper.changer.find_replacement_linux_wallpaperengine_pid",
+                return_value=777,
+            ), patch(
+                "waypaper.changer.change_with_static_fallback"
+            ) as fallback_mock, patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ) as notify_mock:
+                change_with_linux_wallpaperengine(image_path, config, "eDP-1")
+
+            log_text = log_path.read_text(encoding="utf-8")
+            self.assertIn("suppressing launch-failed notification", log_text)
+            fallback_mock.assert_not_called()
+            notify_mock.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wallpaperengine.py
+++ b/tests/test_wallpaperengine.py
@@ -2,7 +2,6 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
 
 from waypaper.wallpaperengine import (
     get_wallpaperengine_image_name,
@@ -42,26 +41,27 @@ class WallpaperEngineTests(unittest.TestCase):
     def test_resolve_binary_prefers_configured_path(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             binary_path = Path(tmp_dir) / "linux-wallpaperengine"
-            binary_path.write_text("", encoding="utf-8")
             config = SimpleNamespace(linux_wallpaperengine_binary=str(binary_path))
 
             self.assertEqual(resolve_linux_wallpaperengine_binary(config), str(binary_path))
 
-    def test_resolve_assets_prefers_configured_directory(self):
+    def test_resolve_binary_defaults_to_command_name(self):
+        config = SimpleNamespace(linux_wallpaperengine_binary="")
+
+        self.assertEqual(resolve_linux_wallpaperengine_binary(config), "linux-wallpaperengine")
+
+    def test_resolve_assets_returns_configured_directory(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             assets_dir = Path(tmp_dir) / "assets"
             assets_dir.mkdir()
-            config = SimpleNamespace(
-                linux_wallpaperengine_assets_dir=str(assets_dir),
-                wallpaperengine_folder="",
-            )
+            config = SimpleNamespace(linux_wallpaperengine_assets_dir=str(assets_dir))
 
-            self.assertEqual(resolve_linux_wallpaperengine_assets_dir(config, "/usr/bin/linux-wallpaperengine"), assets_dir)
+            self.assertEqual(resolve_linux_wallpaperengine_assets_dir(config), assets_dir)
 
-    def test_resolve_binary_uses_path_lookup(self):
-        config = SimpleNamespace(linux_wallpaperengine_binary="linux-wallpaperengine-custom")
-        with patch("waypaper.wallpaperengine.shutil.which", return_value="/usr/bin/linux-wallpaperengine-custom"):
-            self.assertEqual(resolve_linux_wallpaperengine_binary(config), "/usr/bin/linux-wallpaperengine-custom")
+    def test_resolve_assets_returns_none_without_configured_directory(self):
+        config = SimpleNamespace(linux_wallpaperengine_assets_dir="")
+
+        self.assertIsNone(resolve_linux_wallpaperengine_assets_dir(config))
 
 
 if __name__ == "__main__":

--- a/tests/test_wallpaperengine.py
+++ b/tests/test_wallpaperengine.py
@@ -1,0 +1,68 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from waypaper.wallpaperengine import (
+    get_wallpaperengine_image_name,
+    get_wallpaperengine_project,
+    resolve_linux_wallpaperengine_assets_dir,
+    resolve_linux_wallpaperengine_binary,
+)
+
+
+class WallpaperEngineTests(unittest.TestCase):
+    def test_project_metadata_is_normalized_from_preview_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_dir = Path(tmp_dir) / "123"
+            project_dir.mkdir()
+            preview_path = project_dir / "preview.jpg"
+            preview_path.write_text("preview", encoding="utf-8")
+            (project_dir / "project.json").write_text('{"type": " Scene ", "title": "Test Scene"}', encoding="utf-8")
+
+            metadata = get_wallpaperengine_project(preview_path)
+            image_name = get_wallpaperengine_image_name(preview_path)
+
+        self.assertEqual(metadata["type"], "scene")
+        self.assertEqual(metadata["title"], "Test Scene")
+        self.assertEqual(image_name, "Test Scene")
+
+    def test_project_metadata_falls_back_to_directory_name(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_dir = Path(tmp_dir) / "fallback-title"
+            project_dir.mkdir()
+            (project_dir / "project.json").write_text("{}", encoding="utf-8")
+
+            metadata = get_wallpaperengine_project(project_dir)
+
+        self.assertEqual(metadata["type"], "unknown")
+        self.assertEqual(metadata["title"], "fallback-title")
+
+    def test_resolve_binary_prefers_configured_path(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            binary_path = Path(tmp_dir) / "linux-wallpaperengine"
+            binary_path.write_text("", encoding="utf-8")
+            config = SimpleNamespace(linux_wallpaperengine_binary=str(binary_path))
+
+            self.assertEqual(resolve_linux_wallpaperengine_binary(config), str(binary_path))
+
+    def test_resolve_assets_prefers_configured_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            assets_dir = Path(tmp_dir) / "assets"
+            assets_dir.mkdir()
+            config = SimpleNamespace(
+                linux_wallpaperengine_assets_dir=str(assets_dir),
+                wallpaperengine_folder="",
+            )
+
+            self.assertEqual(resolve_linux_wallpaperengine_assets_dir(config, "/usr/bin/linux-wallpaperengine"), assets_dir)
+
+    def test_resolve_binary_uses_path_lookup(self):
+        config = SimpleNamespace(linux_wallpaperengine_binary="linux-wallpaperengine-custom")
+        with patch("waypaper.wallpaperengine.shutil.which", return_value="/usr/bin/linux-wallpaperengine-custom"):
+            self.assertEqual(resolve_linux_wallpaperengine_binary(config), "/usr/bin/linux-wallpaperengine-custom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -12,11 +12,12 @@ from pathlib import Path
 
 from waypaper.changer import change_wallpaper
 from waypaper.config import Config
-from waypaper.common import get_image_paths, get_wallpaperengine_preview, get_image_name, get_random_file, cache_image, get_cached_image_path, get_wallpaperengine_image_name
+from waypaper.common import get_image_paths, get_image_name, get_random_file, cache_image, get_cached_image_path
 from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS, SWWW_TRANSITION_TYPES, SWWW_FILTER_TYPES, \
     get_monitor_options, LINUX_WALLPAPERENGINE_FILL_OPTIONS, LINUX_WALLPAPERENGINE_CLAMP
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 from waypaper.keybindings import Keys
+from waypaper.wallpaperengine import get_wallpaperengine_image_name, get_wallpaperengine_preview
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -34,19 +34,40 @@ def format_post_command(
     return post_command
 
 
-def find_process_pid(command: str | tuple[str, ...]) -> Optional[int]:
-    """Find the PID of the first process containing all required command fragments."""
+def find_process_pids(command: str | tuple[str, ...]) -> list[int]:
+    """Find all PIDs whose command lines contain all required command fragments."""
     try:
         required_fragments = (command,) if isinstance(command, str) else command
         result = subprocess.run(['ps', '-eo', 'pid=,args='], stdout=subprocess.PIPE, text=True, check=True)
         processes = result.stdout.splitlines()
+        matching_pids: list[int] = []
         for process in processes:
             pid_text, _, command_line = process.strip().partition(' ')
             if command_line and all(fragment in command_line for fragment in required_fragments):
-                return int(pid_text)
-        return None
+                matching_pids.append(int(pid_text))
+        return matching_pids
     except Exception:
-        return None
+        return []
+
+
+def find_process_pid(command: str | tuple[str, ...]) -> Optional[int]:
+    """Find the PID of the first process containing all required command fragments."""
+    matching_pids = find_process_pids(command)
+    return matching_pids[0] if matching_pids else None
+
+
+def find_replacement_linux_wallpaperengine_pid(monitor: str, current_pid: int) -> Optional[int]:
+    """Find a newer linux-wallpaperengine PID after the current one was replaced."""
+    command: str | tuple[str, ...]
+    if monitor == "All":
+        command = "linux-wallpaperengine"
+    else:
+        command = ("linux-wallpaperengine", f"--screen-root {monitor}")
+
+    for pid in find_process_pids(command):
+        if pid > current_pid:
+            return pid
+    return None
 
 
 def seek_and_destroy(process: str, monitor: str = "All"):
@@ -577,6 +598,8 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
     command.append(str(background_path))
     print(f"linux-wallpaperengine command: {shlex.join(command)}")
 
+    replacement_pid = None
+
     with log_path.open("w", encoding="utf-8") as log_handle:
         log_handle.write("Waypaper linux-wallpaperengine launch\n")
         log_handle.write(f"Monitor: {monitor}\n")
@@ -609,11 +632,29 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
                 "If the wallpaper appears blank or static, the issue is likely in linux-wallpaperengine runtime behavior or wallpaper content rather than an immediate Waypaper launch failure.\n"
             )
         else:
-            log_handle.write(f"Process status after initial check: exited with code {exit_code}\n")
+            if exit_code == -9:
+                replacement_pid = find_replacement_linux_wallpaperengine_pid(monitor, process.pid)
+            if replacement_pid is not None:
+                log_handle.write(
+                    "Process status after initial check: exited with code "
+                    f"{exit_code}, but a newer linux-wallpaperengine process "
+                    f"(PID {replacement_pid}) is already running for {monitor}; "
+                    "suppressing launch-failed notification.\n"
+                )
+            else:
+                log_handle.write(f"Process status after initial check: exited with code {exit_code}\n")
         log_handle.flush()
 
     print(f"linux-wallpaperengine log file: {log_path}")
     if exit_code is not None:
+        if replacement_pid is not None:
+            print(
+                "linux-wallpaperengine exited with code "
+                f"{exit_code}, but a newer process for {monitor} is already running "
+                f"(PID {replacement_pid}); suppressing failure notification"
+            )
+            return
+
         fallback_backend = None
         if not image_path.is_dir() and image_path.exists():
             fallback_backend = change_with_static_fallback(image_path, cf, monitor)

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -2,16 +2,13 @@
 
 import shlex
 import subprocess
-import shutil
 import time
 from typing import Optional
 from pathlib import Path
-import screeninfo
 
-from waypaper.common import get_wallpaperengine_project
 from waypaper.config import Config
-from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGINE_CLAMP, \
-    LINUX_WALLPAPERENGINE_FILL_OPTIONS
+from waypaper.options import get_monitor_names_with_hyprctl
+from waypaper.wallpaperengine import change_with_linux_wallpaperengine as run_linux_wallpaperengine
 
 
 def format_post_command(
@@ -54,20 +51,6 @@ def find_process_pid(command: str | tuple[str, ...]) -> Optional[int]:
     """Find the PID of the first process containing all required command fragments."""
     matching_pids = find_process_pids(command)
     return matching_pids[0] if matching_pids else None
-
-
-def find_replacement_linux_wallpaperengine_pid(monitor: str, current_pid: int) -> Optional[int]:
-    """Find a newer linux-wallpaperengine PID after the current one was replaced."""
-    command: str | tuple[str, ...]
-    if monitor == "All":
-        command = "linux-wallpaperengine"
-    else:
-        command = ("linux-wallpaperengine", f"--screen-root {monitor}")
-
-    for pid in find_process_pids(command):
-        if pid > current_pid:
-            return pid
-    return None
 
 
 def seek_and_destroy(process: str, monitor: str = "All"):
@@ -115,86 +98,6 @@ def seek_and_destroy(process: str, monitor: str = "All"):
             print(f"Detected {process} on {monitor} and killed it")
         except Exception:
             pass
-
-
-def notify_waypaper_issue(summary: str, body: str) -> None:
-    """Send a simple desktop notification when a wallpaper launch fails."""
-    try:
-        if shutil.which("notify-send"):
-            subprocess.Popen(["notify-send", summary, body], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    except Exception:
-        pass
-
-
-def resolve_linux_wallpaperengine_binary(cf: Config) -> str:
-    configured_binary = getattr(cf, "linux_wallpaperengine_binary", "").strip()
-    if configured_binary:
-        expanded_binary = Path(configured_binary).expanduser()
-        if expanded_binary.exists():
-            return str(expanded_binary)
-        resolved_binary = shutil.which(configured_binary)
-        if resolved_binary:
-            return resolved_binary
-        raise FileNotFoundError(f"Configured linux-wallpaperengine executable was not found: {expanded_binary}")
-
-    resolved_binary = shutil.which("linux-wallpaperengine")
-    if resolved_binary:
-        return resolved_binary
-    raise FileNotFoundError("linux-wallpaperengine executable was not found in PATH")
-
-
-def resolve_linux_wallpaperengine_assets_dir(cf: Config, binary_path: str) -> Optional[Path]:
-    configured_assets = getattr(cf, "linux_wallpaperengine_assets_dir", "").strip()
-    candidates: list[Path] = []
-
-    if configured_assets:
-        candidates.append(Path(configured_assets).expanduser())
-
-    binary_dir = Path(binary_path).expanduser().resolve().parent
-    candidates.append(binary_dir / "assets")
-
-    workshop_dir = getattr(cf, "wallpaperengine_folder", None)
-    if workshop_dir:
-        workshop_path = Path(workshop_dir).expanduser()
-        try:
-            steamapps_dir = workshop_path.parents[2]
-            candidates.append(steamapps_dir / "common" / "wallpaper_engine" / "assets")
-        except IndexError:
-            pass
-
-    candidates.extend([
-        Path("~/.steam/steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.steam/root/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/snap/steam/common/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-    ])
-
-    seen_paths: set[str] = set()
-    for candidate in candidates:
-        candidate_key = str(candidate)
-        if candidate_key in seen_paths:
-            continue
-        seen_paths.add(candidate_key)
-        if candidate.is_dir():
-            return candidate
-    return None
-
-
-def get_linux_wallpaperengine_log_path(cf: Config, monitor: str) -> Path:
-    log_dir = cf.cache_dir / "linux-wallpaperengine"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    safe_monitor = monitor.replace("/", "_")
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    return log_dir / f"{timestamp}-{safe_monitor}.log"
-
-
-def describe_linux_wallpaperengine_pause_policy(cf: Config) -> str:
-    if cf.linux_wallpaperengine_no_fullscreen_pause:
-        return "disabled via --no-fullscreen-pause"
-    if cf.linux_wallpaperengine_fullscreen_pause_only_active:
-        return "limited to the active fullscreen output via --fullscreen-pause-only-active"
-    return "renderer default"
 
 
 def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
@@ -534,136 +437,7 @@ def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):
                 retry_counter += 1
 
 def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str):
-    seek_and_destroy("linux-wallpaperengine", monitor)
-
-    if cf.fill_option.lower() in LINUX_WALLPAPERENGINE_FILL_OPTIONS:
-        fill = cf.fill_option.lower()
-    else:
-        fill = LINUX_WALLPAPERENGINE_FILL_OPTIONS[3]
-
-    background_path = image_path if image_path.is_dir() else image_path.parent
-    if not background_path.exists():
-        raise FileNotFoundError(f"Wallpaper directory does not exist: {background_path}")
-
-    project_metadata = None
-    compatibility_notes: list[str] = []
-    if not image_path.is_dir():
-        try:
-            project_metadata = get_wallpaperengine_project(image_path)
-        except Exception:
-            project_metadata = None
-
-    binary_path = resolve_linux_wallpaperengine_binary(cf)
-    assets_dir = resolve_linux_wallpaperengine_assets_dir(cf, binary_path)
-    log_path = get_linux_wallpaperengine_log_path(cf, monitor)
-    command = [binary_path]
-
-    if monitor == "All":
-        for active_monitor in [m.name for m in screeninfo.get_monitors()]:
-            if active_monitor is not None:
-                command.extend(["--screen-root", active_monitor])
-    else:
-        command.extend(["--screen-root", monitor])
-
-    if cf.linux_wallpaperengine_silent:
-        command.append("--silent")
-    if cf.linux_wallpaperengine_noautomute:
-        command.append("--noautomute")
-    if cf.linux_wallpaperengine_no_audio_processing:
-        command.append("--no-audio-processing")
-    if cf.linux_wallpaperengine_no_fullscreen_pause:
-        command.append("--no-fullscreen-pause")
-    if cf.linux_wallpaperengine_fullscreen_pause_only_active:
-        command.append("--fullscreen-pause-only-active")
-    wallpaper_type = project_metadata.get("type") if project_metadata is not None else None
-    if cf.linux_wallpaperengine_disable_particles and wallpaper_type == "scene":
-        compatibility_notes.append(
-            "Compatibility override: skipped --disable-particles for a scene wallpaper because some animated scenes render nearly static with particles disabled."
-        )
-    elif cf.linux_wallpaperengine_disable_particles:
-        command.append("--disable-particles")
-    if cf.linux_wallpaperengine_disable_mouse:
-        command.append("--disable-mouse")
-    if cf.linux_wallpaperengine_disable_parallax:
-        command.append("--disable-parallax")
-    if cf.linux_wallpaperengine_clamp != LINUX_WALLPAPERENGINE_CLAMP[0]:
-        command.extend(["--clamp", cf.linux_wallpaperengine_clamp])
-
-    command.extend(["--volume", str(cf.linux_wallpaperengine_volume)])
-    command.extend(["--fps", str(cf.linux_wallpaperengine_fps)])
-    command.extend(["--scaling", fill])
-    if assets_dir:
-        command.extend(["--assets-dir", str(assets_dir)])
-
-    command.append(str(background_path))
-    print(f"linux-wallpaperengine command: {shlex.join(command)}")
-
-    replacement_pid = None
-
-    with log_path.open("w", encoding="utf-8") as log_handle:
-        log_handle.write("Waypaper linux-wallpaperengine launch\n")
-        log_handle.write(f"Monitor: {monitor}\n")
-        log_handle.write(f"Background: {background_path}\n")
-        if project_metadata is not None:
-            log_handle.write(f"Wallpaper title: {project_metadata.get('title', background_path.name)}\n")
-            log_handle.write(f"Wallpaper type: {project_metadata.get('type', 'unknown')}\n")
-            if project_metadata.get("file"):
-                log_handle.write(f"Wallpaper entry file: {project_metadata['file']}\n")
-        for note in compatibility_notes:
-            log_handle.write(f"Note: {note}\n")
-        log_handle.write(f"Fullscreen pause policy: {describe_linux_wallpaperengine_pause_policy(cf)}\n")
-        log_handle.write(f"Assets dir: {assets_dir if assets_dir else 'not resolved'}\n")
-        log_handle.write(f"Command: {shlex.join(command)}\n\n")
-        log_handle.flush()
-
-        process = subprocess.Popen(
-            command,
-            stdin=subprocess.DEVNULL,
-            stdout=log_handle,
-            stderr=log_handle,
-            start_new_session=True,
-        )
-        log_handle.write(f"Launch PID: {process.pid}\n")
-        time.sleep(0.5)
-        exit_code = process.poll()
-        if exit_code is None:
-            log_handle.write(
-                "Process status after initial check: still running after 0.5s. "
-                "If the wallpaper appears blank or static, the issue is likely in linux-wallpaperengine runtime behavior or wallpaper content rather than an immediate Waypaper launch failure.\n"
-            )
-        else:
-            if exit_code == -9:
-                replacement_pid = find_replacement_linux_wallpaperengine_pid(monitor, process.pid)
-            if replacement_pid is not None:
-                log_handle.write(
-                    "Process status after initial check: exited with code "
-                    f"{exit_code}, but a newer linux-wallpaperengine process "
-                    f"(PID {replacement_pid}) is already running for {monitor}; "
-                    "suppressing launch-failed notification.\n"
-                )
-            else:
-                log_handle.write(f"Process status after initial check: exited with code {exit_code}\n")
-        log_handle.flush()
-
-    print(f"linux-wallpaperengine log file: {log_path}")
-    if exit_code is not None:
-        if replacement_pid is not None:
-            print(
-                "linux-wallpaperengine exited with code "
-                f"{exit_code}, but a newer process for {monitor} is already running "
-                f"(PID {replacement_pid}); suppressing failure notification"
-            )
-            return
-
-        fallback_backend = None
-        if not image_path.is_dir() and image_path.exists():
-            fallback_backend = change_with_static_fallback(image_path, cf, monitor)
-
-        message = f"linux-wallpaperengine exited immediately with code {exit_code}. See {log_path}"
-        if fallback_backend:
-            message += f" Fallback applied with {fallback_backend}."
-        print(message)
-        notify_waypaper_issue("Waypaper launch failed", message)
+    run_linux_wallpaperengine(image_path, cf, monitor, seek_and_destroy, change_with_static_fallback)
 
 def change_wallpaper(image_path: Path, cf: Config, monitor: str):
     """Run system commands to change the wallpaper depending on the backend"""

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -2,11 +2,13 @@
 
 import shlex
 import subprocess
+import shutil
 import time
 from typing import Optional
 from pathlib import Path
 import screeninfo
 
+from waypaper.common import get_wallpaperengine_project
 from waypaper.config import Config
 from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGINE_CLAMP, \
     LINUX_WALLPAPERENGINE_FILL_OPTIONS
@@ -86,8 +88,80 @@ def seek_and_destroy(process: str, monitor: str = "All"):
         try:
             subprocess.run(['kill', '-9', str(pid)], check=True)
             print(f"Detected {process} on {monitor} and killed it")
-        except Exception as e:
+        except Exception:
             pass
+
+
+def notify_waypaper_issue(summary: str, body: str) -> None:
+    """Send a simple desktop notification when a wallpaper launch fails."""
+    try:
+        if shutil.which("notify-send"):
+            subprocess.Popen(["notify-send", summary, body], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+
+def resolve_linux_wallpaperengine_binary(cf: Config) -> str:
+    configured_binary = getattr(cf, "linux_wallpaperengine_binary", "").strip()
+    if configured_binary:
+        expanded_binary = Path(configured_binary).expanduser()
+        if expanded_binary.exists():
+            return str(expanded_binary)
+        resolved_binary = shutil.which(configured_binary)
+        if resolved_binary:
+            return resolved_binary
+        raise FileNotFoundError(f"Configured linux-wallpaperengine executable was not found: {expanded_binary}")
+
+    resolved_binary = shutil.which("linux-wallpaperengine")
+    if resolved_binary:
+        return resolved_binary
+    raise FileNotFoundError("linux-wallpaperengine executable was not found in PATH")
+
+
+def resolve_linux_wallpaperengine_assets_dir(cf: Config, binary_path: str) -> Optional[Path]:
+    configured_assets = getattr(cf, "linux_wallpaperengine_assets_dir", "").strip()
+    candidates: list[Path] = []
+
+    if configured_assets:
+        candidates.append(Path(configured_assets).expanduser())
+
+    binary_dir = Path(binary_path).expanduser().resolve().parent
+    candidates.append(binary_dir / "assets")
+
+    workshop_dir = getattr(cf, "wallpaperengine_folder", None)
+    if workshop_dir:
+        workshop_path = Path(workshop_dir).expanduser()
+        try:
+            steamapps_dir = workshop_path.parents[2]
+            candidates.append(steamapps_dir / "common" / "wallpaper_engine" / "assets")
+        except IndexError:
+            pass
+
+    candidates.extend([
+        Path("~/.steam/steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.steam/root/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/snap/steam/common/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+    ])
+
+    seen_paths: set[str] = set()
+    for candidate in candidates:
+        candidate_key = str(candidate)
+        if candidate_key in seen_paths:
+            continue
+        seen_paths.add(candidate_key)
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def get_linux_wallpaperengine_log_path(cf: Config, monitor: str) -> Path:
+    log_dir = cf.cache_dir / "linux-wallpaperengine"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_monitor = monitor.replace("/", "_")
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    return log_dir / f"{timestamp}-{safe_monitor}.log"
 
 
 def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
@@ -347,6 +421,35 @@ def change_with_finder(image_path: Path, cf: Config, monitor: str):
     subprocess.Popen(["osascript", "-e", script])
 
 
+def change_with_static_fallback(image_path: Path, cf: Config, monitor: str) -> Optional[str]:
+    fallback_order = ["swww", "awww", "swaybg", "wallutils", "feh", "xwallpaper", "hyprpaper"]
+
+    for backend in fallback_order:
+        if backend not in cf.installed_backends:
+            continue
+        try:
+            if backend == "swww":
+                change_with_swww(image_path, cf, monitor)
+            elif backend == "awww":
+                change_with_awww(image_path, cf, monitor)
+            elif backend == "swaybg":
+                change_with_swaybg(image_path, cf, monitor)
+            elif backend == "wallutils":
+                change_with_wallutils(image_path, cf, monitor)
+            elif backend == "feh":
+                change_with_feh(image_path, cf, monitor)
+            elif backend == "xwallpaper":
+                change_with_xwallpaper(image_path, cf, monitor)
+            elif backend == "hyprpaper":
+                change_with_hyprpaper(image_path, cf, monitor)
+            else:
+                continue
+            return backend
+        except Exception:
+            continue
+    return None
+
+
 def change_with_hyprpaper(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with hyprpaper backend"""
 
@@ -405,12 +508,27 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
     else:
         fill = LINUX_WALLPAPERENGINE_FILL_OPTIONS[3]
 
-    command = ["linux-wallpaperengine"]
+    background_path = image_path if image_path.is_dir() else image_path.parent
+    if not background_path.exists():
+        raise FileNotFoundError(f"Wallpaper directory does not exist: {background_path}")
+
+    project_metadata = None
+    compatibility_notes: list[str] = []
+    if not image_path.is_dir():
+        try:
+            project_metadata = get_wallpaperengine_project(image_path)
+        except Exception:
+            project_metadata = None
+
+    binary_path = resolve_linux_wallpaperengine_binary(cf)
+    assets_dir = resolve_linux_wallpaperengine_assets_dir(cf, binary_path)
+    log_path = get_linux_wallpaperengine_log_path(cf, monitor)
+    command = [binary_path]
 
     if monitor == "All":
-        for monitor in [m.name for m in screeninfo.get_monitors()]:
-            if monitor is not None:
-                command.extend(["--screen-root", monitor])
+        for active_monitor in [m.name for m in screeninfo.get_monitors()]:
+            if active_monitor is not None:
+                command.extend(["--screen-root", active_monitor])
     else:
         command.extend(["--screen-root", monitor])
 
@@ -424,7 +542,12 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
         command.append("--no-fullscreen-pause")
     if cf.linux_wallpaperengine_fullscreen_pause_only_active:
         command.append("--fullscreen-pause-only-active")
-    if cf.linux_wallpaperengine_disable_particles:
+    wallpaper_type = project_metadata.get("type") if project_metadata is not None else None
+    if cf.linux_wallpaperengine_disable_particles and wallpaper_type == "scene":
+        compatibility_notes.append(
+            "Compatibility override: skipped --disable-particles for a scene wallpaper because some animated scenes render nearly static with particles disabled."
+        )
+    elif cf.linux_wallpaperengine_disable_particles:
         command.append("--disable-particles")
     if cf.linux_wallpaperengine_disable_mouse:
         command.append("--disable-mouse")
@@ -436,11 +559,48 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
     command.extend(["--volume", str(cf.linux_wallpaperengine_volume)])
     command.extend(["--fps", str(cf.linux_wallpaperengine_fps)])
     command.extend(["--scaling", fill])
+    if assets_dir:
+        command.extend(["--assets-dir", str(assets_dir)])
 
-    command.append(str(image_path.parent))
-    command.append("&")
-    print(f"{command=}")
-    subprocess.Popen(" ".join(command), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    command.append(str(background_path))
+    print(f"linux-wallpaperengine command: {shlex.join(command)}")
+
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        log_handle.write("Waypaper linux-wallpaperengine launch\n")
+        log_handle.write(f"Monitor: {monitor}\n")
+        log_handle.write(f"Background: {background_path}\n")
+        if project_metadata is not None:
+            log_handle.write(f"Wallpaper title: {project_metadata.get('title', background_path.name)}\n")
+            log_handle.write(f"Wallpaper type: {project_metadata.get('type', 'unknown')}\n")
+            if project_metadata.get("file"):
+                log_handle.write(f"Wallpaper entry file: {project_metadata['file']}\n")
+        for note in compatibility_notes:
+            log_handle.write(f"Note: {note}\n")
+        log_handle.write(f"Assets dir: {assets_dir if assets_dir else 'not resolved'}\n")
+        log_handle.write(f"Command: {shlex.join(command)}\n\n")
+        log_handle.flush()
+
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=log_handle,
+            start_new_session=True,
+        )
+        time.sleep(0.5)
+        exit_code = process.poll()
+
+    print(f"linux-wallpaperengine log file: {log_path}")
+    if exit_code is not None:
+        fallback_backend = None
+        if not image_path.is_dir() and image_path.exists():
+            fallback_backend = change_with_static_fallback(image_path, cf, monitor)
+
+        message = f"linux-wallpaperengine exited immediately with code {exit_code}. See {log_path}"
+        if fallback_backend:
+            message += f" Fallback applied with {fallback_backend}."
+        print(message)
+        notify_waypaper_issue("Waypaper launch failed", message)
 
 def change_wallpaper(image_path: Path, cf: Config, monitor: str):
     """Run system commands to change the wallpaper depending on the backend"""

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -85,6 +85,8 @@ def seek_and_destroy(process: str, monitor: str = "All"):
             pid = find_process_pid(f"linux-wallpaperengine --screen-root {monitor}")
         else:
             return
+        if pid is None:
+            return
         try:
             subprocess.run(['kill', '-9', str(pid)], check=True)
             print(f"Detected {process} on {monitor} and killed it")

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -34,15 +34,16 @@ def format_post_command(
     return post_command
 
 
-def find_process_pid(command: str) -> Optional[int]:
-    """Find the PID of the process matching the exact command"""
+def find_process_pid(command: str | tuple[str, ...]) -> Optional[int]:
+    """Find the PID of the first process containing all required command fragments."""
     try:
-        result = subprocess.run(['ps', 'aux'], stdout=subprocess.PIPE, text=True)
+        required_fragments = (command,) if isinstance(command, str) else command
+        result = subprocess.run(['ps', '-eo', 'pid=,args='], stdout=subprocess.PIPE, text=True, check=True)
         processes = result.stdout.splitlines()
         for process in processes:
-            if command in process:
-                # Extract PID (second column after splitting):
-                return int(process.split()[1])
+            pid_text, _, command_line = process.strip().partition(' ')
+            if command_line and all(fragment in command_line for fragment in required_fragments):
+                return int(pid_text)
         return None
     except Exception:
         return None
@@ -76,13 +77,14 @@ def seek_and_destroy(process: str, monitor: str = "All"):
     # Otherwise, find PID of the process for certain monitor and kill it:
     else:
         if process == "mpvpaper":
-            pid = find_process_pid(f"mpvpaper -f socket-{monitor}")
+            pid = find_process_pid(("mpvpaper", f"socket-{monitor}"))
         elif process == "swaybg":
-            pid = find_process_pid(f"swaybg -o {monitor}")
+            pid = find_process_pid(("swaybg", f"-o {monitor}"))
         elif process == "gslapper":
-            pid = find_process_pid(f"gslapper.*{monitor}")
+            pid = find_process_pid(("gslapper", monitor))
         elif process == "linux-wallpaperengine":
-            pid = find_process_pid(f"linux-wallpaperengine --screen-root {monitor}")
+            # Keep monitor-specific cleanup resilient to future flag reordering.
+            pid = find_process_pid(("linux-wallpaperengine", f"--screen-root {monitor}"))
         else:
             return
         if pid is None:

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -168,6 +168,14 @@ def get_linux_wallpaperengine_log_path(cf: Config, monitor: str) -> Path:
     return log_dir / f"{timestamp}-{safe_monitor}.log"
 
 
+def describe_linux_wallpaperengine_pause_policy(cf: Config) -> str:
+    if cf.linux_wallpaperengine_no_fullscreen_pause:
+        return "disabled via --no-fullscreen-pause"
+    if cf.linux_wallpaperengine_fullscreen_pause_only_active:
+        return "limited to the active fullscreen output via --fullscreen-pause-only-active"
+    return "renderer default"
+
+
 def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with swaybg backend"""
 
@@ -580,6 +588,7 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
                 log_handle.write(f"Wallpaper entry file: {project_metadata['file']}\n")
         for note in compatibility_notes:
             log_handle.write(f"Note: {note}\n")
+        log_handle.write(f"Fullscreen pause policy: {describe_linux_wallpaperengine_pause_policy(cf)}\n")
         log_handle.write(f"Assets dir: {assets_dir if assets_dir else 'not resolved'}\n")
         log_handle.write(f"Command: {shlex.join(command)}\n\n")
         log_handle.flush()
@@ -591,8 +600,17 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
             stderr=log_handle,
             start_new_session=True,
         )
+        log_handle.write(f"Launch PID: {process.pid}\n")
         time.sleep(0.5)
         exit_code = process.poll()
+        if exit_code is None:
+            log_handle.write(
+                "Process status after initial check: still running after 0.5s. "
+                "If the wallpaper appears blank or static, the issue is likely in linux-wallpaperengine runtime behavior or wallpaper content rather than an immediate Waypaper launch failure.\n"
+            )
+        else:
+            log_handle.write(f"Process status after initial check: exited with code {exit_code}\n")
+        log_handle.flush()
 
     print(f"linux-wallpaperengine log file: {log_path}")
     if exit_code is not None:

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -12,12 +12,12 @@ import hashlib
 from pathlib import Path
 from typing import List
 from PIL import Image
-import json
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib
 
 from waypaper.options import IMAGE_EXTENSIONS, BACKEND_OPTIONS, VIDEO_EXTENSIONS
+from waypaper.wallpaperengine import get_wallpaperengine_preview
 
 
 def has_image_extension(file_path: str, backend: str) -> bool:
@@ -64,33 +64,6 @@ def get_image_paths(backend: str,
                     continue
                 image_path_list.append(os.path.join(root, image_name))
     return image_path_list
-
-def get_wallpaperengine_preview(wallpaperengine_folder: Path | str) -> List[str]:
-    image_path_list = []
-    for root, directories, files in os.walk(wallpaperengine_folder):
-        for file in files:
-            if Path(file).stem == "preview":
-                image_path_list.append(os.path.join(root, file))
-    return image_path_list
-
-
-def get_wallpaperengine_project(full_path: Path | str) -> dict:
-    full_path = Path(full_path)
-    image_dir = full_path.parent
-    with open(image_dir / "project.json", "r") as f:
-        project = json.load(f)
-    wallpaper_type = str(project.get("type", "unknown")).strip().lower() or "unknown"
-    project["type"] = wallpaper_type
-    project["title"] = str(project.get("title") or image_dir.name)
-    return project
-
-def get_wallpaperengine_image_name(full_path: Path | str) -> str:
-    full_path = Path(full_path)
-    image_dir = full_path.parent
-    with open(image_dir / "project.json", "r") as f:
-        project = json.load(f)
-    return project["title"]
-
 
 def get_image_name(full_path: str, base_folder_list: list[Path], include_path: bool) ->  str | None:
     """Get image name that may or may not include parent folders"""

--- a/waypaper/common.py
+++ b/waypaper/common.py
@@ -73,6 +73,17 @@ def get_wallpaperengine_preview(wallpaperengine_folder: Path | str) -> List[str]
                 image_path_list.append(os.path.join(root, file))
     return image_path_list
 
+
+def get_wallpaperengine_project(full_path: Path | str) -> dict:
+    full_path = Path(full_path)
+    image_dir = full_path.parent
+    with open(image_dir / "project.json", "r") as f:
+        project = json.load(f)
+    wallpaper_type = str(project.get("type", "unknown")).strip().lower() or "unknown"
+    project["type"] = wallpaper_type
+    project["title"] = str(project.get("title") or image_dir.name)
+    return project
+
 def get_wallpaperengine_image_name(full_path: Path | str) -> str:
     full_path = Path(full_path)
     image_dir = full_path.parent

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -72,6 +72,8 @@ class Config:
         self.linux_wallpaperengine_disable_parallax = False
         self.linux_wallpaperengine_no_fullscreen_pause = False
         self.linux_wallpaperengine_fullscreen_pause_only_active = False
+        self.linux_wallpaperengine_binary = ""
+        self.linux_wallpaperengine_assets_dir = ""
 
         # Create config and cache folders:
         self.config_dir.mkdir(parents=True, exist_ok=True)
@@ -134,10 +136,13 @@ class Config:
         self.style_file = config.get("Settings", "stylesheet", fallback=self.style_file)
         self.keybindings_file = pathlib.Path(config.get("Settings", "keybindings", fallback=self.keybindings_file)).expanduser()
         self.wallpaperengine_folder = pathlib.Path(config.get("Settings", "wallpaperengine_folder", fallback=self.wallpaperengine_folder)).expanduser()
+        legacy_linux_wallpaperengine_binary = config.get("Settings", "wallpaper_engine_script", fallback=self.linux_wallpaperengine_binary)
+        self.linux_wallpaperengine_binary = config.get("Settings", "linux_wallpaperengine_binary", fallback=legacy_linux_wallpaperengine_binary)
+        self.linux_wallpaperengine_assets_dir = config.get("Settings", "linux_wallpaperengine_assets_dir", fallback=self.linux_wallpaperengine_assets_dir)
         self.linux_wallpaperengine_clamp = config.get("Settings", "linux_wallpaperengine_clamp", fallback=self.linux_wallpaperengine_clamp)
         self.linux_wallpaperengine_volume = int(config.get("Settings", "linux_wallpaperengine_volume", fallback=self.linux_wallpaperengine_volume))
         self.linux_wallpaperengine_silent = config.getboolean("Settings", "linux_wallpaperengine_silent", fallback=self.linux_wallpaperengine_silent)
-        self.linux_wallpaperengine_noautomute  = config.getboolean("Settings", "linux_wallpaperengine_silent", fallback=self.linux_wallpaperengine_silent)
+        self.linux_wallpaperengine_noautomute = config.getboolean("Settings", "linux_wallpaperengine_noautomute", fallback=self.linux_wallpaperengine_noautomute)
         self.linux_wallpaperengine_no_audio_processing  = config.getboolean("Settings", "linux_wallpaperengine_no_audio_processing", fallback=self.linux_wallpaperengine_no_audio_processing)
         self.linux_wallpaperengine_fps = int(config.get("Settings", "linux_wallpaperengine_fps", fallback=self.linux_wallpaperengine_fps))
         self.linux_wallpaperengine_disable_particles  = config.getboolean("Settings", "linux_wallpaperengine_disable_particles", fallback=self.linux_wallpaperengine_disable_particles)
@@ -310,6 +315,9 @@ class Config:
         config.set("Settings", "stylesheet", str(self.style_file))
         config.set("Settings", "keybindings", self.shorten_path(self.keybindings_file))
         config.set("Settings", "wallpaperengine_folder", self.shorten_path(self.wallpaperengine_folder))
+        config.set("Settings", "linux_wallpaperengine_binary", str(self.linux_wallpaperengine_binary))
+        config.set("Settings", "wallpaper_engine_script", str(self.linux_wallpaperengine_binary))
+        config.set("Settings", "linux_wallpaperengine_assets_dir", str(self.linux_wallpaperengine_assets_dir))
         config.set("Settings", "linux_wallpaperengine_clamp", self.linux_wallpaperengine_clamp)
         config.set("Settings", "linux_wallpaperengine_volume", str(self.linux_wallpaperengine_volume))
         config.set("Settings", "linux_wallpaperengine_silent", str(self.linux_wallpaperengine_silent))
@@ -320,6 +328,7 @@ class Config:
         config.set("Settings", "linux_wallpaperengine_disable_mouse", str(self.linux_wallpaperengine_disable_mouse))
         config.set("Settings", "linux_wallpaperengine_disable_parallax", str(self.linux_wallpaperengine_disable_parallax))
         config.set("Settings", "linux_wallpaperengine_no_fullscreen_pause", str(self.linux_wallpaperengine_no_fullscreen_pause))
+        config.set("Settings", "linux_wallpaperengine_fullscreen_pause_only_active", str(self.linux_wallpaperengine_fullscreen_pause_only_active))
         try:
             with open(self.config_file, "w") as configfile:
                 config.write(configfile)

--- a/waypaper/wallpaperengine.py
+++ b/waypaper/wallpaperengine.py
@@ -85,55 +85,16 @@ def notify_waypaper_issue(summary: str, body: str) -> None:
 def resolve_linux_wallpaperengine_binary(cf: Any) -> str:
     configured_binary = getattr(cf, "linux_wallpaperengine_binary", "").strip()
     if configured_binary:
-        expanded_binary = Path(configured_binary).expanduser()
-        if expanded_binary.exists():
-            return str(expanded_binary)
-        resolved_binary = shutil.which(configured_binary)
-        if resolved_binary:
-            return resolved_binary
-        raise FileNotFoundError(f"Configured linux-wallpaperengine executable was not found: {expanded_binary}")
+        return str(Path(configured_binary).expanduser())
 
-    resolved_binary = shutil.which("linux-wallpaperengine")
-    if resolved_binary:
-        return resolved_binary
-    raise FileNotFoundError("linux-wallpaperengine executable was not found in PATH")
+    return "linux-wallpaperengine"
 
 
-def resolve_linux_wallpaperengine_assets_dir(cf: Any, binary_path: str) -> Optional[Path]:
+def resolve_linux_wallpaperengine_assets_dir(cf: Any) -> Optional[Path]:
     configured_assets = getattr(cf, "linux_wallpaperengine_assets_dir", "").strip()
-    candidates: list[Path] = []
-
     if configured_assets:
-        candidates.append(Path(configured_assets).expanduser())
+        return Path(configured_assets).expanduser()
 
-    binary_dir = Path(binary_path).expanduser().resolve().parent
-    candidates.append(binary_dir / "assets")
-
-    workshop_dir = getattr(cf, "wallpaperengine_folder", None)
-    if workshop_dir:
-        workshop_path = Path(workshop_dir).expanduser()
-        try:
-            steamapps_dir = workshop_path.parents[2]
-            candidates.append(steamapps_dir / "common" / "wallpaper_engine" / "assets")
-        except IndexError:
-            pass
-
-    candidates.extend([
-        Path("~/.steam/steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.steam/root/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-        Path("~/snap/steam/common/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
-    ])
-
-    seen_paths: set[str] = set()
-    for candidate in candidates:
-        candidate_key = str(candidate)
-        if candidate_key in seen_paths:
-            continue
-        seen_paths.add(candidate_key)
-        if candidate.is_dir():
-            return candidate
     return None
 
 
@@ -179,7 +140,7 @@ def change_with_linux_wallpaperengine(
             project_metadata = None
 
     binary_path = resolve_linux_wallpaperengine_binary(cf)
-    assets_dir = resolve_linux_wallpaperengine_assets_dir(cf, binary_path)
+    assets_dir = resolve_linux_wallpaperengine_assets_dir(cf)
     log_path = get_linux_wallpaperengine_log_path(cf, monitor)
     command = [binary_path]
 

--- a/waypaper/wallpaperengine.py
+++ b/waypaper/wallpaperengine.py
@@ -1,0 +1,291 @@
+"""Wallpaper Engine project helpers and linux-wallpaperengine launcher."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import screeninfo
+
+from waypaper.options import LINUX_WALLPAPERENGINE_CLAMP, LINUX_WALLPAPERENGINE_FILL_OPTIONS
+
+
+StaticFallback = Callable[[Path, Any, str], Optional[str]]
+StopExisting = Callable[[str, str], None]
+
+
+def get_wallpaperengine_preview(wallpaperengine_folder: Path | str) -> list[str]:
+    image_path_list = []
+    for root, directories, files in os.walk(wallpaperengine_folder):
+        for file in files:
+            if Path(file).stem == "preview":
+                image_path_list.append(os.path.join(root, file))
+    return image_path_list
+
+
+def get_wallpaperengine_project(full_path: Path | str) -> dict:
+    full_path = Path(full_path)
+    image_dir = full_path if full_path.is_dir() else full_path.parent
+    with open(image_dir / "project.json", "r", encoding="utf-8") as project_file:
+        project = json.load(project_file)
+    wallpaper_type = str(project.get("type", "unknown")).strip().lower() or "unknown"
+    project["type"] = wallpaper_type
+    project["title"] = str(project.get("title") or image_dir.name)
+    return project
+
+
+def get_wallpaperengine_image_name(full_path: Path | str) -> str:
+    return str(get_wallpaperengine_project(full_path)["title"])
+
+
+def _find_process_pids(command: str | tuple[str, ...]) -> list[int]:
+    try:
+        required_fragments = (command,) if isinstance(command, str) else command
+        result = subprocess.run(['ps', '-eo', 'pid=,args='], stdout=subprocess.PIPE, text=True, check=True)
+        processes = result.stdout.splitlines()
+        matching_pids: list[int] = []
+        for process in processes:
+            pid_text, _, command_line = process.strip().partition(' ')
+            if command_line and all(fragment in command_line for fragment in required_fragments):
+                matching_pids.append(int(pid_text))
+        return matching_pids
+    except Exception:
+        return []
+
+
+def find_replacement_linux_wallpaperengine_pid(monitor: str, current_pid: int) -> Optional[int]:
+    """Find a newer linux-wallpaperengine PID after the current one was replaced."""
+    command: str | tuple[str, ...]
+    if monitor == "All":
+        command = "linux-wallpaperengine"
+    else:
+        command = ("linux-wallpaperengine", f"--screen-root {monitor}")
+
+    for pid in _find_process_pids(command):
+        if pid > current_pid:
+            return pid
+    return None
+
+
+def notify_waypaper_issue(summary: str, body: str) -> None:
+    """Send a simple desktop notification when a wallpaper launch fails."""
+    try:
+        if shutil.which("notify-send"):
+            subprocess.Popen(["notify-send", summary, body], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
+
+
+def resolve_linux_wallpaperengine_binary(cf: Any) -> str:
+    configured_binary = getattr(cf, "linux_wallpaperengine_binary", "").strip()
+    if configured_binary:
+        expanded_binary = Path(configured_binary).expanduser()
+        if expanded_binary.exists():
+            return str(expanded_binary)
+        resolved_binary = shutil.which(configured_binary)
+        if resolved_binary:
+            return resolved_binary
+        raise FileNotFoundError(f"Configured linux-wallpaperengine executable was not found: {expanded_binary}")
+
+    resolved_binary = shutil.which("linux-wallpaperengine")
+    if resolved_binary:
+        return resolved_binary
+    raise FileNotFoundError("linux-wallpaperengine executable was not found in PATH")
+
+
+def resolve_linux_wallpaperengine_assets_dir(cf: Any, binary_path: str) -> Optional[Path]:
+    configured_assets = getattr(cf, "linux_wallpaperengine_assets_dir", "").strip()
+    candidates: list[Path] = []
+
+    if configured_assets:
+        candidates.append(Path(configured_assets).expanduser())
+
+    binary_dir = Path(binary_path).expanduser().resolve().parent
+    candidates.append(binary_dir / "assets")
+
+    workshop_dir = getattr(cf, "wallpaperengine_folder", None)
+    if workshop_dir:
+        workshop_path = Path(workshop_dir).expanduser()
+        try:
+            steamapps_dir = workshop_path.parents[2]
+            candidates.append(steamapps_dir / "common" / "wallpaper_engine" / "assets")
+        except IndexError:
+            pass
+
+    candidates.extend([
+        Path("~/.steam/steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.steam/root/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+        Path("~/snap/steam/common/.local/share/Steam/steamapps/common/wallpaper_engine/assets").expanduser(),
+    ])
+
+    seen_paths: set[str] = set()
+    for candidate in candidates:
+        candidate_key = str(candidate)
+        if candidate_key in seen_paths:
+            continue
+        seen_paths.add(candidate_key)
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def get_linux_wallpaperengine_log_path(cf: Any, monitor: str) -> Path:
+    log_dir = cf.cache_dir / "linux-wallpaperengine"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_monitor = monitor.replace("/", "_")
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    return log_dir / f"{timestamp}-{safe_monitor}.log"
+
+
+def describe_linux_wallpaperengine_pause_policy(cf: Any) -> str:
+    if cf.linux_wallpaperengine_no_fullscreen_pause:
+        return "disabled via --no-fullscreen-pause"
+    if cf.linux_wallpaperengine_fullscreen_pause_only_active:
+        return "limited to the active fullscreen output via --fullscreen-pause-only-active"
+    return "renderer default"
+
+
+def change_with_linux_wallpaperengine(
+        image_path: Path,
+        cf: Any,
+        monitor: str,
+        stop_existing: StopExisting,
+        static_fallback: StaticFallback) -> None:
+    stop_existing("linux-wallpaperengine", monitor)
+
+    if cf.fill_option.lower() in LINUX_WALLPAPERENGINE_FILL_OPTIONS:
+        fill = cf.fill_option.lower()
+    else:
+        fill = LINUX_WALLPAPERENGINE_FILL_OPTIONS[3]
+
+    background_path = image_path if image_path.is_dir() else image_path.parent
+    if not background_path.exists():
+        raise FileNotFoundError(f"Wallpaper directory does not exist: {background_path}")
+
+    project_metadata = None
+    compatibility_notes: list[str] = []
+    if not image_path.is_dir():
+        try:
+            project_metadata = get_wallpaperengine_project(image_path)
+        except Exception:
+            project_metadata = None
+
+    binary_path = resolve_linux_wallpaperengine_binary(cf)
+    assets_dir = resolve_linux_wallpaperengine_assets_dir(cf, binary_path)
+    log_path = get_linux_wallpaperengine_log_path(cf, monitor)
+    command = [binary_path]
+
+    if monitor == "All":
+        for active_monitor in [m.name for m in screeninfo.get_monitors()]:
+            if active_monitor is not None:
+                command.extend(["--screen-root", active_monitor])
+    else:
+        command.extend(["--screen-root", monitor])
+
+    if cf.linux_wallpaperengine_silent:
+        command.append("--silent")
+    if cf.linux_wallpaperengine_noautomute:
+        command.append("--noautomute")
+    if cf.linux_wallpaperengine_no_audio_processing:
+        command.append("--no-audio-processing")
+    if cf.linux_wallpaperengine_no_fullscreen_pause:
+        command.append("--no-fullscreen-pause")
+    if cf.linux_wallpaperengine_fullscreen_pause_only_active:
+        command.append("--fullscreen-pause-only-active")
+    wallpaper_type = project_metadata.get("type") if project_metadata is not None else None
+    if cf.linux_wallpaperengine_disable_particles and wallpaper_type == "scene":
+        compatibility_notes.append(
+            "Compatibility override: skipped --disable-particles for a scene wallpaper because some animated scenes render nearly static with particles disabled."
+        )
+    elif cf.linux_wallpaperengine_disable_particles:
+        command.append("--disable-particles")
+    if cf.linux_wallpaperengine_disable_mouse:
+        command.append("--disable-mouse")
+    if cf.linux_wallpaperengine_disable_parallax:
+        command.append("--disable-parallax")
+    if cf.linux_wallpaperengine_clamp != LINUX_WALLPAPERENGINE_CLAMP[0]:
+        command.extend(["--clamp", cf.linux_wallpaperengine_clamp])
+
+    command.extend(["--volume", str(cf.linux_wallpaperengine_volume)])
+    command.extend(["--fps", str(cf.linux_wallpaperengine_fps)])
+    command.extend(["--scaling", fill])
+    if assets_dir:
+        command.extend(["--assets-dir", str(assets_dir)])
+
+    command.append(str(background_path))
+    print(f"linux-wallpaperengine command: {shlex.join(command)}")
+
+    replacement_pid = None
+
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        log_handle.write("Waypaper linux-wallpaperengine launch\n")
+        log_handle.write(f"Monitor: {monitor}\n")
+        log_handle.write(f"Background: {background_path}\n")
+        if project_metadata is not None:
+            log_handle.write(f"Wallpaper title: {project_metadata.get('title', background_path.name)}\n")
+            log_handle.write(f"Wallpaper type: {project_metadata.get('type', 'unknown')}\n")
+            if project_metadata.get("file"):
+                log_handle.write(f"Wallpaper entry file: {project_metadata['file']}\n")
+        for note in compatibility_notes:
+            log_handle.write(f"Note: {note}\n")
+        log_handle.write(f"Fullscreen pause policy: {describe_linux_wallpaperengine_pause_policy(cf)}\n")
+        log_handle.write(f"Assets dir: {assets_dir if assets_dir else 'not resolved'}\n")
+        log_handle.write(f"Command: {shlex.join(command)}\n\n")
+        log_handle.flush()
+
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=log_handle,
+            start_new_session=True,
+        )
+        log_handle.write(f"Launch PID: {process.pid}\n")
+        time.sleep(0.5)
+        exit_code = process.poll()
+        if exit_code is None:
+            log_handle.write(
+                "Process status after initial check: still running after 0.5s. "
+                "If the wallpaper appears blank or static, the issue is likely in linux-wallpaperengine runtime behavior or wallpaper content rather than an immediate Waypaper launch failure.\n"
+            )
+        else:
+            if exit_code == -9:
+                replacement_pid = find_replacement_linux_wallpaperengine_pid(monitor, process.pid)
+            if replacement_pid is not None:
+                log_handle.write(
+                    "Process status after initial check: exited with code "
+                    f"{exit_code}, but a newer linux-wallpaperengine process "
+                    f"(PID {replacement_pid}) is already running for {monitor}; "
+                    "suppressing launch-failed notification.\n"
+                )
+            else:
+                log_handle.write(f"Process status after initial check: exited with code {exit_code}\n")
+        log_handle.flush()
+
+    print(f"linux-wallpaperengine log file: {log_path}")
+    if exit_code is not None:
+        if replacement_pid is not None:
+            print(
+                "linux-wallpaperengine exited with code "
+                f"{exit_code}, but a newer process for {monitor} is already running "
+                f"(PID {replacement_pid}); suppressing failure notification"
+            )
+            return
+
+        fallback_backend = None
+        if not image_path.is_dir() and image_path.exists():
+            fallback_backend = static_fallback(image_path, cf, monitor)
+
+        message = f"linux-wallpaperengine exited immediately with code {exit_code}. See {log_path}"
+        if fallback_backend:
+            message += f" Fallback applied with {fallback_backend}."
+        print(message)
+        notify_waypaper_issue("Waypaper launch failed", message)


### PR DESCRIPTION
Closes #276

## Summary

Harden the linux-wallpaperengine launch path while keeping the generic wallpaper changer clean. The PR follows the requested module boundary: Wallpaper Engine project metadata, per-launch logging, deterministic CLI argument assembly, and immediate-exit handling live in `waypaper/wallpaperengine.py`; `changer.py` only delegates to that module from `change_with_linux_wallpaperengine()`.

## What changed

- Add `waypaper/wallpaperengine.py` for Wallpaper Engine-specific behavior:
  - project metadata/title normalization from `project.json`
  - preview/title helpers used by the UI and random selection
  - per-launch log path creation and launch diagnostics
  - immediate-exit reporting, static fallback, and replaced-process suppression
- Keep `waypaper/changer.py` focused on generic backend orchestration, process cleanup helpers, and the high-level backend dispatch.
- Keep config parsing/persistence in `waypaper/config.py`, including the `linux_wallpaperengine_noautomute` key fix and explicit binary/assets override settings.
- Update the app imports so Wallpaper Engine helpers come from `waypaper/wallpaperengine.py` rather than living in `common.py`.
- Preserve the already-merged post_command shell-token quoting from #288 after rebasing onto current `origin/main`.
- Remove runtime Steam/assets-dir probing and launcher-side `shutil.which()` prevalidation from the execution path:
  - `linux_wallpaperengine_assets_dir` is now treated as an explicit config passthrough only
  - `linux_wallpaperengine_binary` is treated as an explicit override only
  - otherwise Waypaper invokes the plain `linux-wallpaperengine` command and relies on the existing GUI/backend availability guards

## Compatibility notes

The cleanup path keeps tuple-based fragment matching rather than a single contiguous command string, so monitor-specific process collection remains stable if executable paths are absolute or flags are reorganized.

The same fragment matcher makes monitor cleanup explicit for backends such as `gslapper` and `linux-wallpaperengine`: it matches the backend name and monitor as separate command fragments instead of relying on one fragile substring.

## Scope boundary

- No daemon/systemd GUI integration in this PR.
- No DMS/Niri/private local notification path in this PR.
- No runtime Steam layout guessing in this PR.
- No default policy change such as changing fullscreen-pause behavior.
- No backend rerouting in this PR.
- This is launcher-path hardening, config compatibility, process cleanup, logging, and failure reporting only.

## Validation

- `python3 -m py_compile waypaper/*.py tests/test_linux_wallpaperengine_logging.py tests/test_wallpaperengine.py`
- `python3 -m unittest discover -s tests`
- `git diff --check`
- Rebased onto current `origin/main`, preserving #288 post_command quoting behavior.

Current result: 21 tests pass.
