### PR TITLE
Package waypaperd as a console script and ship a user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,26 @@ Waypaper is available in an external repository owned by Solopasha. You can add 
 
 `waypaper` command will run GUI application.
 
+`waypaperd` runs a simple slideshow daemon that periodically triggers `waypaper --random`.
+
 To restore your wallpaper after restart, add `waypaper --restore` to [your WM startup config](https://anufrievroman.gitbook.io/waypaper/usage).
+
+### Slideshow daemon service
+
+Packaged installations also ship a `waypaperd.service` user unit. You can enable it with:
+
+`systemctl --user daemon-reload && systemctl --user enable --now waypaperd.service`
+
+The unit defaults to a 30-minute interval. To override that without editing the installed unit directly, create a drop-in:
+
+```ini
+systemctl --user edit waypaperd.service
+
+[Service]
+Environment=WAYPAPERD_INTERVAL=600
+```
+
+Then restart the service with `systemctl --user restart waypaperd.service`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Waypaper is available in an external repository owned by Solopasha. You can add 
 
 `waypaper` command will run GUI application.
 
-`waypaperd` runs a simple slideshow daemon that periodically triggers `waypaper --random`.
+`waypaperd` runs a simple slideshow daemon that periodically triggers `waypaper --random`. If no interval argument is passed, it reads `waypaperd_cycle_length` from Waypaper's configuration and falls back to 30 minutes.
 
 To restore your wallpaper after restart, add `waypaper --restore` to [your WM startup config](https://anufrievroman.gitbook.io/waypaper/usage).
 
@@ -76,16 +76,7 @@ Packaged installations also ship a `waypaperd.service` user unit. You can enable
 
 `systemctl --user daemon-reload && systemctl --user enable --now waypaperd.service`
 
-The unit defaults to a 30-minute interval. To override that without editing the installed unit directly, create a drop-in:
-
-```ini
-systemctl --user edit waypaperd.service
-
-[Service]
-Environment=WAYPAPERD_INTERVAL=600
-```
-
-Then restart the service with `systemctl --user restart waypaperd.service`.
+The unit starts `waypaperd` without systemd-specific interval overrides, so the daemon follows Waypaper's normal configuration path.
 
 ## Documentation
 

--- a/data/waypaperd.service
+++ b/data/waypaperd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Waypaper slideshow daemon
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=WAYPAPERD_INTERVAL=1800
+ExecStart=/usr/bin/env waypaperd ${WAYPAPERD_INTERVAL}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/data/waypaperd.service
+++ b/data/waypaperd.service
@@ -6,9 +6,7 @@ PartOf=graphical-session.target
 
 [Service]
 Type=simple
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
-Environment=WAYPAPERD_INTERVAL=1800
-ExecStart=/usr/bin/env waypaperd ${WAYPAPERD_INTERVAL}
+ExecStart=waypaperd
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=10

--- a/data/waypaperd.service
+++ b/data/waypaperd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Waypaper slideshow daemon
+Documentation=https://anufrievroman.gitbook.io/waypaper/
 After=graphical-session.target
 PartOf=graphical-session.target
 
@@ -10,6 +11,9 @@ Environment=WAYPAPERD_INTERVAL=1800
 ExecStart=/usr/bin/env waypaperd ${WAYPAPERD_INTERVAL}
 Restart=on-failure
 RestartSec=5
+TimeoutStopSec=10
+KillMode=control-group
+NoNewPrivileges=true
 
 [Install]
 WantedBy=default.target

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setuptools.setup(
     entry_points={
         "gui_scripts": [
             "waypaper = waypaper.__main__:run"
+        ],
+        "console_scripts": [
+            "waypaperd = waypaper.waypaperd:main"
         ]
     },
     install_requires=["PyGObject", "platformdirs", "Pillow", "imageio", "imageio-ffmpeg", "screeninfo"],
@@ -50,6 +53,9 @@ setuptools.setup(
          ),
         ('share/man/man1',
          ['data/waypaper.1.gz']
+         ),
+        ('share/systemd/user',
+         ['data/waypaperd.service']
          ),
     ],
 )

--- a/tests/test_waypaperd.py
+++ b/tests/test_waypaperd.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import unittest
 from unittest.mock import patch
@@ -15,7 +16,7 @@ class WaypaperdTests(unittest.TestCase):
         self.assertEqual(args.interval, 600)
 
     def test_positive_interval_rejects_non_positive_values(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(argparse.ArgumentTypeError):
             waypaperd.positive_interval("0")
 
     def test_build_waypaper_command_uses_current_python(self):

--- a/tests/test_waypaperd.py
+++ b/tests/test_waypaperd.py
@@ -1,0 +1,41 @@
+import sys
+import unittest
+from unittest.mock import patch
+
+from waypaper import waypaperd
+
+
+class WaypaperdTests(unittest.TestCase):
+    def test_parse_args_uses_default_interval(self):
+        args = waypaperd.parse_args([])
+        self.assertEqual(args.interval, waypaperd.DEFAULT_INTERVAL_SECONDS)
+
+    def test_parse_args_accepts_custom_interval(self):
+        args = waypaperd.parse_args(["600"])
+        self.assertEqual(args.interval, 600)
+
+    def test_positive_interval_rejects_non_positive_values(self):
+        with self.assertRaises(Exception):
+            waypaperd.positive_interval("0")
+
+    def test_build_waypaper_command_uses_current_python(self):
+        self.assertEqual(
+            waypaperd.build_waypaper_command(),
+            [sys.executable, "-m", "waypaper", "--random"],
+        )
+
+    def test_trigger_random_wallpaper_returns_subprocess_code(self):
+        with patch("waypaper.waypaperd.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 7
+            self.assertEqual(waypaperd.trigger_random_wallpaper(["waypaper"]), 7)
+            run_mock.assert_called_once_with(["waypaper"], check=False)
+
+    def test_main_exits_cleanly_on_keyboard_interrupt(self):
+        with patch("waypaper.waypaperd.trigger_random_wallpaper", return_value=0), patch(
+            "waypaper.waypaperd.time.sleep", side_effect=KeyboardInterrupt
+        ):
+            self.assertEqual(waypaperd.main(["60"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_waypaperd.py
+++ b/tests/test_waypaperd.py
@@ -7,13 +7,31 @@ from waypaper import waypaperd
 
 
 class WaypaperdTests(unittest.TestCase):
-    def test_parse_args_uses_default_interval(self):
+    def test_parse_args_leaves_interval_unset_by_default(self):
         args = waypaperd.parse_args([])
-        self.assertEqual(args.interval, waypaperd.DEFAULT_INTERVAL_SECONDS)
+        self.assertIsNone(args.interval)
 
     def test_parse_args_accepts_custom_interval(self):
         args = waypaperd.parse_args(["600"])
         self.assertEqual(args.interval, 600)
+
+    def test_resolve_interval_uses_config_when_no_argument_is_given(self):
+        with patch("waypaper.waypaperd.read_config_interval", return_value=900):
+            self.assertEqual(waypaperd.resolve_interval(None), 900)
+
+    def test_resolve_interval_prefers_explicit_argument(self):
+        with patch("waypaper.waypaperd.read_config_interval") as read_config_interval:
+            self.assertEqual(waypaperd.resolve_interval(600), 600)
+            read_config_interval.assert_not_called()
+
+    def test_read_config_interval_uses_waypaper_config(self):
+        with patch("waypaper.waypaperd.Config") as config_class:
+            config = config_class.return_value
+            config.waypaperd_cycle_length = 1200
+
+            self.assertEqual(waypaperd.read_config_interval(), 1200)
+            config.read.assert_called_once_with()
+            config.check_validity.assert_called_once_with()
 
     def test_positive_interval_rejects_non_positive_values(self):
         with self.assertRaises(argparse.ArgumentTypeError):
@@ -32,10 +50,12 @@ class WaypaperdTests(unittest.TestCase):
             run_mock.assert_called_once_with(["waypaper"], check=False)
 
     def test_main_exits_cleanly_on_keyboard_interrupt(self):
-        with patch("waypaper.waypaperd.trigger_random_wallpaper", return_value=0), patch(
+        with patch("waypaper.waypaperd.resolve_interval", return_value=60), patch(
+            "waypaper.waypaperd.trigger_random_wallpaper", return_value=0
+        ), patch(
             "waypaper.waypaperd.time.sleep", side_effect=KeyboardInterrupt
         ):
-            self.assertEqual(waypaperd.main(["60"]), 0)
+            self.assertEqual(waypaperd.main([]), 0)
 
 
 if __name__ == "__main__":

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -54,6 +54,7 @@ class Config:
         self.use_xdg_state = False
         self.use_post_command = True
         self.show_path_in_tooltip = True
+        self.waypaperd_cycle_length = 1800
 
         # options for linux-wallpaperengine
         self.linux_wallpaperengine_clamp = LINUX_WALLPAPERENGINE_CLAMP[0]
@@ -121,6 +122,7 @@ class Config:
         self.zen_mode = config.getboolean("Settings", "zen_mode", fallback=self.zen_mode)
         self.use_xdg_state = config.getboolean("Settings", "use_xdg_state", fallback=self.use_xdg_state)
         self.show_path_in_tooltip = config.getboolean("Settings", "show_path_in_tooltip", fallback=self.show_path_in_tooltip)
+        self.waypaperd_cycle_length = int(config.get("Settings", "waypaperd_cycle_length", fallback=self.waypaperd_cycle_length))
         self.style_file = config.get("Settings", "stylesheet", fallback=self.style_file)
         self.keybindings_file = pathlib.Path(config.get("Settings", "keybindings", fallback=self.keybindings_file)).expanduser()
         self.wallpaperengine_folder = pathlib.Path(config.get("Settings", "wallpaperengine_folder", fallback=self.wallpaperengine_folder)).expanduser()
@@ -193,6 +195,8 @@ class Config:
             self.swww_transition_duration = 2
         if 0 > int(self.swww_transition_fps):
             self.swww_transition_fps = 60
+        if int(self.waypaperd_cycle_length) <= 0:
+            self.waypaperd_cycle_length = 1800
 
 
     def attribute_selected_wallpaper(self) -> None:
@@ -271,6 +275,7 @@ class Config:
         config.set("Settings", "show_gifs_only", str(self.show_gifs_only))
         config.set("Settings", "zen_mode", str(self.zen_mode))
         config.set("Settings", "post_command", self.post_command)
+        config.set("Settings", "waypaperd_cycle_length", str(self.waypaperd_cycle_length))
         config.set("Settings", "number_of_columns", str(self.number_of_columns))
         config.set("Settings", "swww_transition_type", str(self.swww_transition_type))
         config.set("Settings", "swww_transition_step", str(self.swww_transition_step))

--- a/waypaper/waypaperd.py
+++ b/waypaper/waypaperd.py
@@ -1,24 +1,69 @@
-"""
-This is a daemon that randomly changes wallpaper every specified number of minutes.
-THIS IS WORK IN PROGRESS AND NOT USED IN THE PROGRAM YET.
-"""
+"""Small daemon that periodically triggers `waypaper --random`."""
 
-import time
-import os
 import argparse
+import logging
+import subprocess
+import sys
+import time
+from typing import Sequence
 
-def main():
-    parser = argparse.ArgumentParser(description="Randomly changes wallpaper every specified number of seconds.")
-    parser.add_argument("interval", type=int, help="Time interval in seconds until next wallpaper change.")
-    args = parser.parse_args()
 
+DEFAULT_INTERVAL_SECONDS = 1800
+LOG = logging.getLogger(__name__)
+
+
+def positive_interval(value: str) -> int:
+    interval = int(value)
+    if interval <= 0:
+        raise argparse.ArgumentTypeError("interval must be a positive integer")
+    return interval
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Randomly changes wallpaper every specified number of seconds."
+    )
+    parser.add_argument(
+        "interval",
+        nargs="?",
+        default=DEFAULT_INTERVAL_SECONDS,
+        type=positive_interval,
+        help="Time interval in seconds between random wallpaper changes.",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def build_waypaper_command() -> list[str]:
+    return [sys.executable, "-m", "waypaper", "--random"]
+
+
+def trigger_random_wallpaper(command: Sequence[str] | None = None) -> int:
+    result = subprocess.run(
+        list(command) if command is not None else build_waypaper_command(),
+        check=False,
+    )
+    if result.returncode == 0:
+        LOG.info("Random wallpaper command completed successfully.")
+    else:
+        LOG.warning("Random wallpaper command exited with status %s.", result.returncode)
+    return result.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = parse_args(argv)
+    command = build_waypaper_command()
+
+    LOG.info("Starting waypaperd with interval=%s seconds.", args.interval)
     try:
         while True:
-            os.system("waypaper --random")
-            print(f"Command to change wallpaper executed. Waiting {args.interval} seconds.")
+            trigger_random_wallpaper(command)
+            LOG.info("Sleeping for %s seconds.", args.interval)
             time.sleep(args.interval)
     except KeyboardInterrupt:
-        print("Program interrupted. Exiting.")
+        LOG.info("waypaperd interrupted, exiting cleanly.")
+        return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/waypaper/waypaperd.py
+++ b/waypaper/waypaperd.py
@@ -7,6 +7,8 @@ import sys
 import time
 from typing import Sequence
 
+from waypaper.config import Config
+
 
 DEFAULT_INTERVAL_SECONDS = 1800
 LOG = logging.getLogger(__name__)
@@ -26,11 +28,24 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "interval",
         nargs="?",
-        default=DEFAULT_INTERVAL_SECONDS,
+        default=None,
         type=positive_interval,
-        help="Time interval in seconds between random wallpaper changes.",
+        help="Time interval in seconds between random wallpaper changes. Defaults to the Waypaper config value.",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def read_config_interval() -> int:
+    config = Config()
+    config.read()
+    config.check_validity()
+    return int(config.waypaperd_cycle_length)
+
+
+def resolve_interval(interval: int | None) -> int:
+    if interval is not None:
+        return interval
+    return read_config_interval()
 
 
 def build_waypaper_command() -> list[str]:
@@ -52,14 +67,15 @@ def trigger_random_wallpaper(command: Sequence[str] | None = None) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     args = parse_args(argv)
+    interval = resolve_interval(args.interval)
     command = build_waypaper_command()
 
-    LOG.info("Starting waypaperd with interval=%s seconds.", args.interval)
+    LOG.info("Starting waypaperd with interval=%s seconds.", interval)
     try:
         while True:
             trigger_random_wallpaper(command)
-            LOG.info("Sleeping for %s seconds.", args.interval)
-            time.sleep(args.interval)
+            LOG.info("Sleeping for %s seconds.", interval)
+            time.sleep(interval)
     except KeyboardInterrupt:
         LOG.info("waypaperd interrupted, exiting cleanly.")
         return 0

--- a/waypaper/waypaperd.py
+++ b/waypaper/waypaperd.py
@@ -9,8 +9,6 @@ from typing import Sequence
 
 from waypaper.config import Config
 
-
-DEFAULT_INTERVAL_SECONDS = 1800
 LOG = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Closes #282

Follow-up to #167, but scoped specifically to packaging and service integration. Also relates to #249: the daemon can stay simple and use Python subprocess primitives without adding another daemonization dependency.

## Summary

- install `waypaperd` as a real `console_scripts` entry point in the existing `setup.py` flow
- harden `waypaper/waypaperd.py` so it validates intervals and calls `sys.executable -m waypaper --random` instead of shelling out through `os.system`
- ship a standard `data/waypaperd.service` user unit that runs `waypaperd` without a service-specific interval environment override
- keep the default interval source of truth in Waypaper config: `waypaperd_cycle_length`, with the daemon fallback still at 1800 seconds
- preserve explicit direct CLI usage such as `waypaperd 600` for users who want to run the daemon manually
- document the user-service path in the README without adding a new `CONTRIBUTING.md` or hardcoding project-specific virtualenv paths
- add focused unit tests for the daemon helpers

## Why This Shape

- The packaging problem Roman called out in #167 is the root blocker: `waypaperd` needs to be installed as a command before a reusable service file makes sense.
- #249 showed that this path does not need a new external daemonization dependency; standard subprocess/service primitives are enough.
- Keeping `waypaper` as `gui_scripts` and adding `waypaperd` as `console_scripts` stays aligned with the current packaging model instead of broadening this into a metadata migration.
- The service file is installed under `share/systemd/user`, so standard package installs can enable it directly.
- The unit uses `/usr/bin/env` plus a conservative `PATH` that includes `%h/.local/bin`, which keeps it usable for common user installs without embedding repo-specific paths.
- Avoiding `WAYPAPERD_INTERVAL` in the service keeps config, future UI controls, and no-arg service startup from disagreeing about the default interval.

## Scope Boundary

- No UI controls in this PR.
- No packaging metadata migration beyond the existing `setup.py` flow.
- No new dependency for daemon management.
- No unrelated contribution-process docs.
- No session-readiness shim in this PR; startup environment hardening can be a follow-up once the service path exists.

## Validation

- `python3 -m unittest discover -s tests`
- `python3 setup.py bdist_wheel -d "$TMPDIR/waypaperd-wheelcheck-latest"`
- Verified the wheel contains `waypaper-2.8.dist-info/entry_points.txt` and `share/systemd/user/waypaperd.service`
- `systemd-analyze --user verify data/waypaperd.service`
