### PR TITLE
Expose swww/awww filter option

### DIFF
--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from waypaper.changer import change_wallpaper
 from waypaper.config import Config
 from waypaper.common import get_image_paths, get_wallpaperengine_preview, get_image_name, get_random_file, cache_image, get_cached_image_path, get_wallpaperengine_image_name
-from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS, SWWW_TRANSITION_TYPES, \
+from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EXTENSIONS, SWWW_TRANSITION_TYPES, SWWW_FILTER_TYPES, \
     get_monitor_options, LINUX_WALLPAPERENGINE_FILL_OPTIONS, LINUX_WALLPAPERENGINE_CLAMP
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 from waypaper.keybindings import Keys
@@ -231,6 +231,7 @@ class App(Gtk.Window):
 
         # Create a transition type dropdown menu for swww
         self.swww_transitions_options = Gtk.ComboBoxText()
+        self.swww_filter_options = Gtk.ComboBoxText()
 
         #  Get angle for animation
         self.swww_angle_entry = Gtk.Entry()
@@ -474,6 +475,7 @@ class App(Gtk.Window):
     def swww_or_awww_options_display(self) -> None:
         """Show swww transition options if backend is swww or awww"""
         self.options_box.remove(self.swww_transitions_options)
+        self.options_box.remove(self.swww_filter_options)
         self.options_box.remove(self.swww_angle_entry)
         self.options_box.remove(self.swww_steps_entry)
         self.options_box.remove(self.swww_fps_entry)
@@ -492,10 +494,21 @@ class App(Gtk.Window):
             self.swww_transitions_options.connect("changed", self.on_transition_option_changed)
             self.swww_transitions_options.set_tooltip_text(self.txt.tip_transition)
 
+        self.swww_filter_options = Gtk.ComboBoxText()
+        for filter_type in SWWW_FILTER_TYPES:
+            self.swww_filter_options.append_text(filter_type)
+        active_filter = 0
+        if self.cf.swww_filter in SWWW_FILTER_TYPES:
+            active_filter = SWWW_FILTER_TYPES.index(self.cf.swww_filter)
+        self.swww_filter_options.set_active(active_filter)
+        self.swww_filter_options.connect("changed", self.on_filter_option_changed)
+        self.swww_filter_options.set_tooltip_text(getattr(self.txt, "tip_filter", "Choose scaling filter"))
+
         self.options_box.pack_end(self.swww_steps_entry, False, False, 0)
         self.options_box.pack_end(self.swww_fps_entry, False, False, 0)
         self.options_box.pack_end(self.swww_angle_entry, False, False, 0)
         self.options_box.pack_end(self.swww_duration_entry, False, False, 0)
+        self.options_box.pack_end(self.swww_filter_options, False, False, 0)
         self.options_box.pack_end(self.swww_transitions_options, False, False, 0)
 
     def hyprland_restart_button_display(self) -> None:
@@ -962,6 +975,13 @@ class App(Gtk.Window):
         active_index = combo.get_active()
         self.cf.swww_transition_type = SWWW_TRANSITION_TYPES[active_index]
         print(f"Transition type changed to: {self.cf.swww_transition_type}")
+
+
+    def on_filter_option_changed(self, combo) -> None:
+        """Update the scaling filter based on the selected option"""
+        active_index = combo.get_active()
+        self.cf.swww_filter = SWWW_FILTER_TYPES[active_index]
+        print(f"Filter changed to: {self.cf.swww_filter}")
 
 
     def on_color_set(self, color_button):

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -219,6 +219,7 @@ def change_with_swww(image_path: Path, cf: Config, monitor: str):
         command.extend(["--fill-color", cf.color.lstrip("#")])
     else:
         command.extend(["--fill-color", cf.color])
+    command.extend(["--filter", cf.swww_filter])
     command.extend(["--transition-type", cf.swww_transition_type])
     command.extend(["--transition-step", str(cf.swww_transition_step)])
     command.extend(["--transition-angle", str(cf.swww_transition_angle)])
@@ -263,6 +264,7 @@ def change_with_awww(image_path: Path, cf: Config, monitor: str):
         command.extend(["--fill-color", cf.color.lstrip("#")])
     else:
         command.extend(["--fill-color", cf.color])
+    command.extend(["--filter", cf.swww_filter])
     command.extend(["--transition-type", cf.swww_transition_type])
     command.extend(["--transition-step", str(cf.swww_transition_step)])
     command.extend(["--transition-angle", str(cf.swww_transition_angle)])

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -6,7 +6,7 @@ from argparse import Namespace
 from typing import List
 from platformdirs import user_config_path, user_pictures_path, user_cache_path, user_state_path
 
-from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SWWW_TRANSITION_TYPES, BACKEND_OPTIONS, \
+from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SWWW_TRANSITION_TYPES, SWWW_FILTER_TYPES, BACKEND_OPTIONS, \
     LINUX_WALLPAPERENGINE_CLAMP
 from waypaper.common import check_installed_backends
 
@@ -29,6 +29,7 @@ class Config:
         self.color = "#ffffff"
         self.number_of_columns = 3
         self.swww_transition_type = SWWW_TRANSITION_TYPES[0]
+        self.swww_filter = SWWW_FILTER_TYPES[-1]
         self.swww_transition_step = 63
         self.swww_transition_angle = 0
         self.swww_transition_duration = 2
@@ -106,6 +107,7 @@ class Config:
         self.color = config.get("Settings", "color", fallback=self.color)
         self.post_command = config.get("Settings", "post_command", fallback=self.post_command)
         self.swww_transition_type = config.get("Settings", "swww_transition_type", fallback=self.swww_transition_type)
+        self.swww_filter = config.get("Settings", "swww_filter", fallback=self.swww_filter)
         self.swww_transition_step = config.get("Settings", "swww_transition_step", fallback=self.swww_transition_step)
         self.swww_transition_angle = config.get("Settings", "swww_transition_angle", fallback=self.swww_transition_angle)
         self.swww_transition_duration = config.get("Settings", "swww_transition_duration", fallback=self.swww_transition_duration)
@@ -181,6 +183,14 @@ class Config:
             self.fill_option = FILL_OPTIONS[0]
         if self.swww_transition_type not in SWWW_TRANSITION_TYPES:
             self.swww_transition_type = "any"
+        if self.swww_filter not in SWWW_FILTER_TYPES:
+            self.swww_filter = next(
+                (
+                    filter_type for filter_type in SWWW_FILTER_TYPES
+                    if str(self.swww_filter).lower() == filter_type.lower()
+                ),
+                SWWW_FILTER_TYPES[-1]
+            )
         if self.number_of_columns <= 0:
             self.number_of_columns = 1
 
@@ -273,6 +283,7 @@ class Config:
         config.set("Settings", "post_command", self.post_command)
         config.set("Settings", "number_of_columns", str(self.number_of_columns))
         config.set("Settings", "swww_transition_type", str(self.swww_transition_type))
+        config.set("Settings", "swww_filter", str(self.swww_filter))
         config.set("Settings", "swww_transition_step", str(self.swww_transition_step))
         config.set("Settings", "swww_transition_angle", str(self.swww_transition_angle))
         config.set("Settings", "swww_transition_duration", str(self.swww_transition_duration))

--- a/waypaper/options.py
+++ b/waypaper/options.py
@@ -33,6 +33,7 @@ IMAGE_EXTENSIONS: Dict[str, List[str]] = {
 
 SWWW_TRANSITION_TYPES: List[str] = ["any", "none", "simple", "fade", "wipe",  "left", "right", "top",
                                 "bottom", "wave", "grow", "center", "outer", "random"]
+SWWW_FILTER_TYPES: List[str] = ["Nearest", "Bilinear", "CatmullRom", "Mitchell", "Lanczos3"]
 
 TIMERS: Dict[str, int] = {"30 sec": 30, "1 min": 60, "2 min": 120, "5 min": 300, "10 min": 600, "30 min": 1800, "1 hour": 3600,
           "2 hours": 7200, "6 hours": 21600, "12 hours": 43200, "1 day": 86400, "1 week": 604800}

--- a/waypaper/translations.py
+++ b/waypaper/translations.py
@@ -70,6 +70,7 @@ class English:
         self.tip_random = "Set random wallpaper"
         self.tip_exit = "Exit the application"
         self.tip_transition = "Choose transition type"
+        self.tip_filter = "Choose scaling filter"
         self.tip_mpv_stop = "Stop all all mpv processes"
         self.tip_mpv_pause = "Play/Pause video wallpaper"
         self.tip_mpv_sound = "Play sound of the video"


### PR DESCRIPTION
Closes #285.

This exposes the `--filter` argument shared by `swww img` and `awww img` through Waypaper’s existing config/UI path.

Changes:
- add `swww_filter` config with default `Lanczos3`
- add the filter combo beside the existing transition controls for swww/awww
- pass `--filter <value>` to both backends
- normalize manually edited lower-case values back to the supported capitalization

Validation:
- `python3 -m compileall -q waypaper`
- `python3 -m py_compile waypaper/options.py waypaper/config.py waypaper/changer.py waypaper/app.py waypaper/translations.py`
- `git diff --check`
- verified installed `swww 0.11.2-master2` and `awww 0.12.1` both expose `--filter` with `Nearest | Bilinear | CatmullRom | Mitchell | Lanczos3`
- validated config round-trip and case-normalization, e.g. `nearest` -> `Nearest`
- local mock command-generation check for both `swww` and `awww`, ensuring `--filter <value>` is appended to argv
- launched the GUI with isolated XDG config and synthetic images, then confirmed the filter selector appears with `Bilinear` selected