### PR TITLE
Use the user service to control waypaperd from the GUI

### DIFF
--- a/tests/test_waypaperd_manager.py
+++ b/tests/test_waypaperd_manager.py
@@ -1,0 +1,90 @@
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from waypaper.waypaperd_manager import WaypaperdManager
+
+
+class WaypaperdManagerTests(unittest.TestCase):
+    def test_check_returns_true_when_service_is_active(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            self.assertTrue(WaypaperdManager().check())
+
+            run_mock.assert_called_once_with(
+                ["systemctl", "--user", "is-active", "--quiet", "waypaperd.service"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def test_check_returns_false_when_service_is_inactive(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 3
+
+            self.assertFalse(WaypaperdManager().check())
+
+    def test_launch_starts_service(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            self.assertTrue(WaypaperdManager().launch())
+
+            run_mock.assert_called_once_with(
+                ["systemctl", "--user", "start", "waypaperd.service"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def test_stop_stops_service(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            self.assertTrue(WaypaperdManager().stop())
+
+            run_mock.assert_called_once_with(
+                ["systemctl", "--user", "stop", "waypaperd.service"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def test_restart_restarts_service(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+
+            self.assertTrue(WaypaperdManager().restart())
+
+            run_mock.assert_called_once_with(
+                ["systemctl", "--user", "restart", "waypaperd.service"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+    def test_kill_uses_service_stop(self):
+        with patch.object(WaypaperdManager, "stop", return_value=True) as stop_mock:
+            self.assertTrue(WaypaperdManager().kill())
+            stop_mock.assert_called_once_with()
+
+    def test_commands_return_false_when_systemctl_is_missing(self):
+        with patch("waypaper.waypaperd_manager.subprocess.run", side_effect=FileNotFoundError):
+            manager = WaypaperdManager()
+
+            self.assertFalse(manager.check())
+            self.assertFalse(manager.launch())
+            self.assertFalse(manager.stop())
+            self.assertFalse(manager.restart())
+
+    def test_is_supported_checks_systemctl_on_path(self):
+        with patch("waypaper.waypaperd_manager.shutil.which", return_value="/usr/bin/systemctl"):
+            self.assertTrue(WaypaperdManager().is_supported())
+
+        with patch("waypaper.waypaperd_manager.shutil.which", return_value=None):
+            self.assertFalse(WaypaperdManager().is_supported())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/waypaper/__main__.py
+++ b/waypaper/__main__.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os.path
-import subprocess
 import sys
 import time
 import json
@@ -15,6 +14,7 @@ from waypaper.common import get_random_file
 from waypaper.config import Config
 from waypaper.options import BACKEND_OPTIONS, FILL_OPTIONS, get_monitor_options
 from waypaper.translations import load_language
+from waypaper.waypaperd_manager import WaypaperdManager
 
 
 __version__ = "2.8"
@@ -113,10 +113,8 @@ def run():
 
         # On restore, restart the daemon if slideshow was enabled:
         if args.restore and cf.slideshow_enabled:
-            try:
-                subprocess.Popen(["waypaperd", str(cf.slideshow_interval * 60)])
-            except FileNotFoundError:
-                print("Couldn't launch the daemon for automatic wallpaper change. See documentation on how to enable it.")
+            if not WaypaperdManager().restart():
+                print("Couldn't control the waypaperd user service. See documentation on how to enable it.")
 
         sys.exit(0)
 

--- a/waypaper/app.py
+++ b/waypaper/app.py
@@ -17,6 +17,7 @@ from waypaper.options import FILL_OPTIONS, SORT_OPTIONS, SORT_DISPLAYS, VIDEO_EX
     get_monitor_options, LINUX_WALLPAPERENGINE_FILL_OPTIONS, LINUX_WALLPAPERENGINE_CLAMP
 from waypaper.translations import Chinese, English, French, German, Polish, Russian, Belarusian, Spanish
 from waypaper.keybindings import Keys
+from waypaper.waypaperd_manager import WaypaperdManager
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib
@@ -30,6 +31,7 @@ class App(Gtk.Window):
         self.cf = cf
         self.txt = txt
         self.keys = Keys(cf)
+        self.waypaperd_manager = WaypaperdManager()
         self.check_backends()
         self.set_default_size(820, 600)
         self.connect("delete-event", Gtk.main_quit)
@@ -1084,11 +1086,14 @@ class App(Gtk.Window):
             print("Pause not supported for gSlapper")
 
     def is_waypaperd_running(self) -> bool:
-        result = subprocess.run(["pgrep", "-f", "waypaperd"], capture_output=True)
-        return result.returncode == 0
+        return self.waypaperd_manager.check()
 
     def update_slideshow_button(self) -> None:
-        if self.is_waypaperd_running():
+        is_supported = self.waypaperd_manager.is_supported()
+        is_running = self.is_waypaperd_running()
+        self.slideshow_start_button.set_sensitive(is_supported)
+        self.slideshow_stop_button.set_sensitive(is_supported and is_running)
+        if is_running:
             self.slideshow_start_button.set_label(self.txt.msg_daemon_restart)
         else:
             self.slideshow_start_button.set_label(self.txt.msg_daemon_start)
@@ -1101,21 +1106,34 @@ class App(Gtk.Window):
                 interval_minutes = 60
         except ValueError:
             interval_minutes = 60
-        subprocess.run(["pkill", "-f", "waypaperd"], capture_output=True)
-        try:
-            subprocess.Popen(["waypaperd", str(interval_minutes * 60)])
-            self.cf.slideshow_interval = interval_minutes
-            self.cf.slideshow_enabled = True
-            self.cf.save()
-            self.slideshow_start_button.set_label(self.txt.msg_daemon_restart)
-        except FileNotFoundError:
-            print("Couldn't launch the daemon for automatic wallpaper change. See documentation on how to enable it.")
+
+        self.cf.slideshow_interval = interval_minutes
+        self.cf.slideshow_enabled = True
+        self.cf.save()
+
+        if self.is_waypaperd_running():
+            success = self.waypaperd_manager.restart()
+        else:
+            success = self.waypaperd_manager.launch()
+
+        if success:
+            self.update_slideshow_button()
+            return
+
+        self.cf.slideshow_enabled = self.is_waypaperd_running()
+        self.cf.save()
+        self.update_slideshow_button()
+        print("Couldn't control the waypaperd user service. See documentation on how to enable it.")
 
     def on_daemon_stop_clicked(self, widget) -> None:
-        subprocess.run(["pkill", "-f", "waypaperd"], capture_output=True)
-        self.cf.slideshow_enabled = False
-        self.cf.save()
-        self.slideshow_start_button.set_label(self.txt.msg_daemon_start)
+        success = self.waypaperd_manager.stop()
+        if success or not self.is_waypaperd_running():
+            self.cf.slideshow_enabled = False
+            self.cf.save()
+            self.update_slideshow_button()
+            return
+
+        print("Couldn't stop the waypaperd user service. See documentation on how to enable it.")
 
     def on_slideshow_panel_toggled(self, toggle) -> None:
         self.cf.show_slideshow_panel = toggle.get_active()

--- a/waypaper/waypaperd_manager.py
+++ b/waypaper/waypaperd_manager.py
@@ -1,0 +1,49 @@
+"""Systemd user-service wrapper for waypaperd."""
+
+import shutil
+import subprocess
+
+
+class WaypaperdManager:
+    """Control waypaperd through the systemd user service."""
+
+    def __init__(self, service_name: str = "waypaperd.service") -> None:
+        self.service_name = service_name
+
+    def is_supported(self) -> bool:
+        return shutil.which("systemctl") is not None
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["systemctl", "--user", *args, self.service_name],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def check(self) -> bool:
+        try:
+            return self._run("is-active", "--quiet").returncode == 0
+        except (FileNotFoundError, OSError):
+            return False
+
+    def launch(self) -> bool:
+        try:
+            return self._run("start").returncode == 0
+        except (FileNotFoundError, OSError):
+            return False
+
+    def stop(self) -> bool:
+        try:
+            return self._run("stop").returncode == 0
+        except (FileNotFoundError, OSError):
+            return False
+
+    def restart(self) -> bool:
+        try:
+            return self._run("restart").returncode == 0
+        except (FileNotFoundError, OSError):
+            return False
+
+    def kill(self) -> bool:
+        return self.stop()


### PR DESCRIPTION
## Summary

This wires the new slideshow panel controls to the packaged `waypaperd.service` from #283 instead of launching or stopping the daemon directly from the GUI process.

## Why

The initial `Popen` approach is useful as a proof of concept, but now that `waypaperd` is installed as a console script and user service, the GUI can keep daemon lifecycle ownership in one place: `systemctl --user`.

That avoids splitting daemon ownership between the GUI and name-based process checks. The user service owns start/stop/restart behavior, process cleanup, and journal logs.

## What changed

- Add a small `WaypaperdManager` wrapper around `systemctl --user is-active/start/stop/restart waypaperd.service`.
- Keep the current slideshow panel and config-saving flow, but use the manager for Start/Restart/Stop.
- Use the same manager from `waypaper --restore` when slideshow mode is enabled.
- Keep unsupported systems explicit: if `systemctl` is not available, the controls are disabled.
- Re-check the real service state after command failures before updating button labels.
- Add unit tests for the service wrapper.

## Validation

- `python3 -m py_compile waypaper/app.py waypaper/__main__.py waypaper/waypaperd_manager.py tests/test_waypaperd_manager.py`
- `python3 -m unittest tests.test_waypaperd_manager`
- `rg -n 'pgrep.*waypaperd|pkill.*waypaperd|Popen\(\["waypaperd"|subprocess\.Popen\(\["waypaperd"' waypaper tests`