### PR TITLE
security: sanitize dynamic post_command tokens via shlex.quote

### DIFF
--- a/tests/test_post_command.py
+++ b/tests/test_post_command.py
@@ -1,0 +1,47 @@
+import shlex
+import unittest
+from pathlib import Path
+
+from waypaper.changer import format_post_command
+
+
+class PostCommandTests(unittest.TestCase):
+    def test_format_post_command_quotes_dynamic_tokens(self):
+        image_path = Path("/tmp/wallpapers/bg; unexpected command.png")
+        monitor = "HDMI-A-1; unexpected command"
+        fill_option = "fill && unexpected command"
+        color = "#112233; unexpected command"
+
+        command = format_post_command(
+            "notify-send $wallpaper $monitor $fill $color && echo done",
+            image_path,
+            monitor,
+            fill_option,
+            color,
+        )
+
+        self.assertEqual(
+            command,
+            "notify-send "
+            f"{shlex.quote(str(image_path))} "
+            f"{shlex.quote(monitor)} "
+            f"{shlex.quote(fill_option)} "
+            f"{shlex.quote(color)} "
+            "&& echo done",
+        )
+
+    def test_format_post_command_handles_apostrophes_in_paths(self):
+        command = format_post_command(
+            "printf %s $wallpaper",
+            Path("/tmp/Don't Look Down.jpg"),
+            "All",
+            "fill",
+            "#000000",
+        )
+
+        self.assertIn("'\"'\"'", command)
+        self.assertTrue(command.startswith("printf %s "))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -1,5 +1,6 @@
 """Module that runs the system processes to change the wallpaper"""
 
+import shlex
 import subprocess
 import time
 from typing import Optional
@@ -9,6 +10,26 @@ import screeninfo
 from waypaper.config import Config
 from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGINE_CLAMP, \
     LINUX_WALLPAPERENGINE_FILL_OPTIONS
+
+
+def format_post_command(
+        post_command: str,
+        image_path: Path,
+        monitor: str,
+        fill_option: str,
+        color: str) -> str:
+    """Replace post_command tokens while treating dynamic values as shell literals."""
+    replacements = {
+        "$wallpaper": shlex.quote(str(image_path)),
+        "$monitor": shlex.quote(monitor),
+        "$fill": shlex.quote(fill_option),
+        "$color": shlex.quote(color),
+    }
+
+    for token, value in replacements.items():
+        post_command = post_command.replace(token, value)
+
+    return post_command
 
 
 def find_process_pid(command: str) -> Optional[int]:
@@ -455,11 +476,13 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
 
         # Run a post command:
         if cf.post_command and cf.use_post_command:
-            modified_image_path = str(image_path).replace(" ", "\\ ")
-            post_command = cf.post_command.replace("$wallpaper", modified_image_path)
-            post_command = post_command.replace("$monitor", monitor)
-            post_command = post_command.replace("$fill", cf.fill_option)
-            post_command = post_command.replace("$color", cf.color)
+            post_command = format_post_command(
+                cf.post_command,
+                image_path,
+                monitor,
+                cf.fill_option,
+                cf.color,
+            )
             subprocess.Popen(post_command, shell=True)
             print(f'Executed "{post_command}" post-command\n')
 


### PR DESCRIPTION
## Summary

This quotes the dynamic tokens substituted into `post_command` before the command is evaluated through `subprocess.Popen(..., shell=True)`.

## Context

The recent `$fill` and `$color` keyword addition made this shell boundary more visible. This PR keeps the feature and keeps `shell=True` intact for compatibility with user-authored post commands that rely on pipes, redirects, `&&`, or other shell syntax.

The only change is that app-provided dynamic values are converted to shell literals with `shlex.quote()` before substitution:

- `$wallpaper`
- `$monitor`
- `$fill`
- `$color`

That makes filenames, display names, fill modes, and color values behave as data even if they contain spaces, apostrophes, semicolons, `$()`, or other shell metacharacters.

## What changed

- Add `format_post_command()` to render the user template with quoted dynamic values.
- Use it in `change_wallpaper()` before calling `subprocess.Popen(..., shell=True)`.
- Add focused unit tests for semicolons, shell operators, and apostrophes in dynamic token values.

## Validation

- `python3 -m py_compile waypaper/changer.py tests/test_post_command.py tests/test_waypaperd.py`
- `python3 -m unittest tests.test_post_command tests.test_waypaperd`
- `git diff --check origin/main...HEAD`

## Additional context

I also wrote a generic note about this pattern, separate from this project, because it comes up often in desktop automation features that combine user shell templates with app-provided dynamic values:

https://gist.github.com/louzt/45891a115be800f5c256e8a739684303
