### PR TITLE
Notify users when linux-wallpaperengine exits immediately

### DIFF
--- a/tests/test_linux_wallpaperengine_notification.py
+++ b/tests/test_linux_wallpaperengine_notification.py
@@ -1,0 +1,78 @@
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from waypaper.changer import change_with_linux_wallpaperengine
+
+
+class LinuxWallpaperengineNotificationTests(unittest.TestCase):
+    def make_config(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            fill_option="fill",
+            linux_wallpaperengine_silent=True,
+            linux_wallpaperengine_noautomute=True,
+            linux_wallpaperengine_no_audio_processing=False,
+            linux_wallpaperengine_no_fullscreen_pause=False,
+            linux_wallpaperengine_fullscreen_pause_only_active=False,
+            linux_wallpaperengine_disable_particles=True,
+            linux_wallpaperengine_disable_mouse=False,
+            linux_wallpaperengine_disable_parallax=False,
+            linux_wallpaperengine_clamp="none",
+            linux_wallpaperengine_volume=15,
+            linux_wallpaperengine_fps=30,
+        )
+
+    def make_preview_path(self, tmp_dir: str) -> Path:
+        wallpaper_dir = Path(tmp_dir) / "wallpaper"
+        wallpaper_dir.mkdir()
+        preview_path = wallpaper_dir / "preview.jpg"
+        preview_path.write_text("preview", encoding="utf-8")
+        return preview_path
+
+    def test_running_process_does_not_notify(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            process = MagicMock()
+            process.poll.return_value = None
+
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=process
+            ) as popen_mock, patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ) as notify_mock:
+                change_with_linux_wallpaperengine(
+                    self.make_preview_path(tmp_dir),
+                    self.make_config(),
+                    "DP-1",
+                )
+
+        command = popen_mock.call_args.args[0]
+        self.assertNotIn("&", command)
+        self.assertTrue(popen_mock.call_args.kwargs["start_new_session"])
+        notify_mock.assert_not_called()
+
+    def test_immediate_exit_notifies_user(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            process = MagicMock()
+            process.poll.return_value = 7
+
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=process
+            ), patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ) as notify_mock:
+                change_with_linux_wallpaperengine(
+                    self.make_preview_path(tmp_dir),
+                    self.make_config(),
+                    "DP-1",
+                )
+
+        notify_mock.assert_called_once()
+        summary, message = notify_mock.call_args.args
+        self.assertEqual(summary, "Waypaper launch failed")
+        self.assertIn("linux-wallpaperengine exited immediately with code 7", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -90,6 +90,19 @@ def seek_and_destroy(process: str, monitor: str = "All"):
             pass
 
 
+def notify_waypaper_issue(summary: str, body: str) -> None:
+    """Show a desktop notification when a wallpaper backend fails."""
+    try:
+        subprocess.Popen(
+            ["notify-send", summary, body],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        pass
+
+
 def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with swaybg backend"""
 
@@ -438,9 +451,20 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
     command.extend(["--scaling", fill])
 
     command.append(str(image_path.parent))
-    command.append("&")
     print(f"{command=}")
-    subprocess.Popen(" ".join(command), shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    time.sleep(0.5)
+    exit_code = process.poll()
+    if exit_code is not None:
+        message = f"linux-wallpaperengine exited immediately with code {exit_code}."
+        print(message)
+        notify_waypaper_issue("Waypaper launch failed", message)
 
 def change_wallpaper(image_path: Path, cf: Config, monitor: str):
     """Run system commands to change the wallpaper depending on the backend"""


### PR DESCRIPTION
## Summary

Split from #279 to keep the first user-visible fix small and easy to review.

This changes the `linux-wallpaperengine` launch path from a shell-backgrounded command to an argv `Popen()` process that Waypaper can observe briefly after launch. If the renderer exits immediately, Waypaper now prints a clear message and sends a desktop notification when `notify-send` is available.

## Why

Silent `linux-wallpaperengine` launch exits are hard to diagnose because the previous shell-backgrounded launch path discarded stdout/stderr and did not keep a process handle that Waypaper could check.

This PR only surfaces the immediate failure to the user. It does not include the larger logging/refactor work from #279.

## What changed

- Launch `linux-wallpaperengine` with argv `Popen()` instead of `shell=True` plus `&`.
- Start the renderer in a new session so Waypaper does not need shell backgrounding.
- Poll the process after a short initial delay.
- Notify the user if the renderer exited immediately.
- Add unit coverage for the running-process and immediate-exit paths.

## Validation

```text
python3 -m py_compile waypaper/*.py tests/test_linux_wallpaperengine_notification.py
python3 -m unittest discover -s tests
git diff --check
```

Result: 13 tests pass.

## Follow-ups

The broader #279 branch still contains logging, fallback, process cleanup, and module-boundary hardening. Those can be rebased/split separately after this smaller piece is reviewed.
