### PR TITLE
feat(changer): write external wallpaper override file for compositor coordination

### DIFF
--- a/tests/test_changer_writes_override.py
+++ b/tests/test_changer_writes_override.py
@@ -1,0 +1,170 @@
+"""Integration tests for the override_file wiring inside changer.py.
+
+Verify that each change_with_X (swww, awww, swaybg, mpvpaper, gslapper,
+linux-wallpaperengine) records an override entry with the right backend
+name and PID, and that change_wallpaper clears any stale entry for the
+monitor before launching a new backend.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from waypaper import changer, override_file
+from waypaper.changer import change_wallpaper
+
+
+def _lwe_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        backend="linux-wallpaperengine",
+        fill_option="fill",
+        linux_wallpaperengine_silent=True,
+        linux_wallpaperengine_noautomute=True,
+        linux_wallpaperengine_no_audio_processing=False,
+        linux_wallpaperengine_no_fullscreen_pause=False,
+        linux_wallpaperengine_fullscreen_pause_only_active=False,
+        linux_wallpaperengine_disable_particles=True,
+        linux_wallpaperengine_disable_mouse=False,
+        linux_wallpaperengine_disable_parallax=False,
+        linux_wallpaperengine_clamp=changer.LINUX_WALLPAPERENGINE_CLAMP[0],
+        linux_wallpaperengine_volume=15,
+        linux_wallpaperengine_fps=30,
+        post_command="",
+        use_post_command=False,
+    )
+
+
+def _make_process(pid: int = 12345) -> MagicMock:
+    p = MagicMock()
+    p.pid = pid
+    p.poll.return_value = None  # still running
+    return p
+
+
+class ChangeWithLinuxWallpaperengineWritesOverrideTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-int-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_writes_override_after_popen(self):
+        """The override is recorded with backend=linux-wallpaperengine and the new PID."""
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(99999)
+            ) as popen_mock, patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ):
+                changer.change_with_linux_wallpaperengine(
+                    self.tmp / "preview.jpg", _lwe_config(), "HDMI-A-1"
+                )
+
+        # The override file MUST contain the entry for the new process.
+        data = json.loads((self.tmp / "ov.json").read_text(encoding="utf-8"))
+        self.assertIn("HDMI-A-1", data["overrides"])
+        self.assertEqual(data["overrides"]["HDMI-A-1"]["backend"], "linux-wallpaperengine")
+        self.assertEqual(data["overrides"]["HDMI-A-1"]["pid"], 99999)
+
+
+class ChangeWallpaperClearsStaleOverrideTests(unittest.TestCase):
+    """When the user changes wallpaper, any prior override for that monitor must be cleared."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-clear-"))
+        self.path = self.tmp / "ov.json"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_stale_entry_for_same_monitor_is_replaced(self):
+        """A previous override for the same monitor is replaced, not appended to."""
+        # Pre-existing stale entry (the user previously had swww on HDMI-A-1
+        # but the daemon died, leaving a stale entry).
+        override_file.set_override("HDMI-A-1", "swww", 100, self.path)
+        self.assertIn("HDMI-A-1", override_file.read_overrides(self.path))
+
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(555)
+            ), patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ):
+                change_wallpaper(self.tmp / "wp", _lwe_config(), "HDMI-A-1")
+
+        result = override_file.read_overrides(self.path)
+        # Old swww entry is gone; only the new lwe entry remains.
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result["HDMI-A-1"]["backend"], "linux-wallpaperengine")
+        self.assertEqual(result["HDMI-A-1"]["pid"], 555)
+
+
+class ChangeWithSwaybgWritesOverrideTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-swaybg-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_writes_override_with_swaybg_backend(self):
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+        cfg = SimpleNamespace(fill_option="fill", color="#000000", post_command="", use_post_command=False)
+        with patch.dict(__import__("os").environ, env, clear=False):
+            with patch("waypaper.changer.find_process_pid", return_value=None), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(7777)
+            ) as popen_mock, patch("waypaper.changer.subprocess.run"):
+                changer.change_with_swaybg(self.tmp / "image.jpg", cfg, "DP-1")
+
+        data = json.loads((self.tmp / "ov.json").read_text(encoding="utf-8"))
+        self.assertEqual(data["overrides"]["DP-1"]["backend"], "swaybg")
+        self.assertEqual(data["overrides"]["DP-1"]["pid"], 7777)
+
+
+class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
+    """For swww/awww, the override records the long-running daemon's PID, not the short-lived `swww img` PID."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-swww-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_swww_writes_daemon_pid(self):
+        cfg = SimpleNamespace(
+            fill_option="fill", color="#000000",
+            swww_filter="lanczos3", swww_transition_type="fade",
+            swww_transition_step=1, swww_transition_angle=0,
+            swww_transition_duration=1, swww_transition_fps=30,
+        )
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+
+        # Mock pgrep to return a specific daemon PID
+        pgrep_result = MagicMock(returncode=0, stdout="42424\n")
+        run_result = MagicMock(stdout="swww 0.11.0")
+
+        with patch.dict(__import__("os").environ, env, clear=False):
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.check_output", return_value="42424"
+            ), patch("waypaper.changer.subprocess.run", return_value=run_result), patch(
+                "waypaper.changer.subprocess.Popen"
+            ):
+                changer.change_with_swww(self.tmp / "image.jpg", cfg, "HDMI-A-1")
+
+        data = json.loads((self.tmp / "ov.json").read_text(encoding="utf-8"))
+        self.assertEqual(data["overrides"]["HDMI-A-1"]["backend"], "swww")
+        self.assertEqual(data["overrides"]["HDMI-A-1"]["pid"], 42424)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_changer_writes_override.py
+++ b/tests/test_changer_writes_override.py
@@ -131,7 +131,7 @@ class ChangeWithSwaybgWritesOverrideTests(unittest.TestCase):
 
 
 class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
-    """For swww/awww, the override records the long-running daemon's PID, not the short-lived `swww img` PID."""
+    """For swww, the override records the long-running daemon's PID, not the short-lived `swww img` PID."""
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-swww-"))
@@ -149,14 +149,10 @@ class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
         )
         env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
 
-        # Mock pgrep to return a specific daemon PID
-        pgrep_result = MagicMock(returncode=0, stdout="42424\n")
-        run_result = MagicMock(stdout="swww 0.11.0")
-
         with patch.dict(__import__("os").environ, env, clear=False):
             with patch("waypaper.changer.seek_and_destroy"), patch(
                 "waypaper.changer.subprocess.check_output", return_value="42424"
-            ), patch("waypaper.changer.subprocess.run", return_value=run_result), patch(
+            ), patch("waypaper.changer.subprocess.run", return_value=MagicMock(stdout="swww 0.11.0")), patch(
                 "waypaper.changer.subprocess.Popen"
             ):
                 changer.change_with_swww(self.tmp / "image.jpg", cfg, "HDMI-A-1")
@@ -164,6 +160,51 @@ class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
         data = json.loads((self.tmp / "ov.json").read_text(encoding="utf-8"))
         self.assertEqual(data["overrides"]["HDMI-A-1"]["backend"], "swww")
         self.assertEqual(data["overrides"]["HDMI-A-1"]["pid"], 42424)
+
+
+class AtexitLivenessCheckTests(unittest.TestCase):
+    """The atexit hook must keep entries whose backing process is still alive.
+
+    Critical for CLI mode: `waypaper --wallpaper foo` exits while lwe keeps
+    running. The override must remain so DMS can detect ownership.
+    """
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-atexit-"))
+        self.path = self.tmp / "ov.json"
+        # Pretend there's a real process running (this very test process).
+        self.alive_pid = __import__("os").getpid()
+        # Use an obviously-dead pid (max int → no process).
+        self.dead_pid = 2**30
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_atexit_keeps_live_entries(self):
+        override_file.set_override("HDMI-A-1", "linux-wallpaperengine", self.alive_pid, self.path)
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            changer._atexit_cleanup_overrides()
+        result = override_file.read_overrides(self.path)
+        self.assertIn("HDMI-A-1", result, "live entries must survive atexit")
+
+    def test_atexit_clears_dead_entries(self):
+        override_file.set_override("HDMI-A-1", "linux-wallpaperengine", self.dead_pid, self.path)
+        override_file.set_override("DP-1", "swww", self.alive_pid, self.path)
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            changer._atexit_cleanup_overrides()
+        result = override_file.read_overrides(self.path)
+        self.assertNotIn("HDMI-A-1", result, "dead entries must be cleared")
+        self.assertIn("DP-1", result, "live entries must be preserved")
+
+    def test_atexit_handles_missing_file_gracefully(self):
+        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            # Should not raise even if file doesn't exist
+            changer._atexit_cleanup_overrides()
+        self.assertFalse(self.path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_changer_writes_override.py
+++ b/tests/test_changer_writes_override.py
@@ -34,6 +34,7 @@ def _lwe_config() -> SimpleNamespace:
         linux_wallpaperengine_fps=30,
         post_command="",
         use_post_command=False,
+        write_override_file=True,
     )
 
 
@@ -55,7 +56,7 @@ class ChangeWithLinuxWallpaperengineWritesOverrideTests(unittest.TestCase):
 
     def test_writes_override_after_popen(self):
         """The override is recorded with backend=linux-wallpaperengine and the new PID."""
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
         with patch.dict(__import__("os").environ, env, clear=False):
             with patch("waypaper.changer.seek_and_destroy"), patch(
                 "waypaper.changer.subprocess.Popen", return_value=_make_process(99999)
@@ -91,7 +92,7 @@ class ChangeWallpaperClearsStaleOverrideTests(unittest.TestCase):
         override_file.set_override("HDMI-A-1", "swww", 100, self.path)
         self.assertIn("HDMI-A-1", override_file.read_overrides(self.path))
 
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.path)}
         with patch.dict(__import__("os").environ, env, clear=False):
             with patch("waypaper.changer.seek_and_destroy"), patch(
                 "waypaper.changer.subprocess.Popen", return_value=_make_process(555)
@@ -117,8 +118,12 @@ class ChangeWithSwaybgWritesOverrideTests(unittest.TestCase):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def test_writes_override_with_swaybg_backend(self):
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
-        cfg = SimpleNamespace(fill_option="fill", color="#000000", post_command="", use_post_command=False)
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+        cfg = SimpleNamespace(
+            fill_option="fill", color="#000000",
+            post_command="", use_post_command=False,
+            write_override_file=True,
+        )
         with patch.dict(__import__("os").environ, env, clear=False):
             with patch("waypaper.changer.find_process_pid", return_value=None), patch(
                 "waypaper.changer.subprocess.Popen", return_value=_make_process(7777)
@@ -146,8 +151,9 @@ class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
             swww_filter="lanczos3", swww_transition_type="fade",
             swww_transition_step=1, swww_transition_angle=0,
             swww_transition_duration=1, swww_transition_fps=30,
+            write_override_file=True,
         )
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.tmp / "ov.json")}
 
         with patch.dict(__import__("os").environ, env, clear=False):
             with patch("waypaper.changer.seek_and_destroy"), patch(
@@ -162,49 +168,73 @@ class ChangeWithSwwwWritesDaemonPidTests(unittest.TestCase):
         self.assertEqual(data["overrides"]["HDMI-A-1"]["pid"], 42424)
 
 
-class AtexitLivenessCheckTests(unittest.TestCase):
-    """The atexit hook must keep entries whose backing process is still alive.
+class WriteOverrideFileFlagGateTests(unittest.TestCase):
+    """When cf.write_override_file is False (the default), no override is recorded.
 
-    Critical for CLI mode: `waypaper --wallpaper foo` exits while lwe keeps
-    running. The override must remain so DMS can detect ownership.
+    The flag is opt-in to keep the surface area minimal for the 95% of users
+    who don't coordinate with external compositors.
     """
 
     def setUp(self):
-        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-atexit-"))
+        self.tmp = Path(tempfile.mkdtemp(prefix="wp-ov-flag-"))
         self.path = self.tmp / "ov.json"
-        # Pretend there's a real process running (this very test process).
-        self.alive_pid = __import__("os").getpid()
-        # Use an obviously-dead pid (max int → no process).
-        self.dead_pid = 2**30
 
     def tearDown(self):
         import shutil
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_atexit_keeps_live_entries(self):
-        override_file.set_override("HDMI-A-1", "linux-wallpaperengine", self.alive_pid, self.path)
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
-        with patch.dict(__import__("os").environ, env, clear=False):
-            changer._atexit_cleanup_overrides()
-        result = override_file.read_overrides(self.path)
-        self.assertIn("HDMI-A-1", result, "live entries must survive atexit")
+    def _disabled_cfg(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            fill_option="fill", color="#000000",
+            post_command="", use_post_command=False,
+            write_override_file=False,
+        )
 
-    def test_atexit_clears_dead_entries(self):
-        override_file.set_override("HDMI-A-1", "linux-wallpaperengine", self.dead_pid, self.path)
-        override_file.set_override("DP-1", "swww", self.alive_pid, self.path)
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+    def test_swaybg_skips_override_when_flag_disabled(self):
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.path)}
         with patch.dict(__import__("os").environ, env, clear=False):
-            changer._atexit_cleanup_overrides()
-        result = override_file.read_overrides(self.path)
-        self.assertNotIn("HDMI-A-1", result, "dead entries must be cleared")
-        self.assertIn("DP-1", result, "live entries must be preserved")
+            with patch("waypaper.changer.find_process_pid", return_value=None), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(7777)
+            ), patch("waypaper.changer.subprocess.run"):
+                changer.change_with_swaybg(self.tmp / "image.jpg", self._disabled_cfg(), "DP-1")
 
-    def test_atexit_handles_missing_file_gracefully(self):
-        env = {**__import__("os").environ, "LZT_WALLPAPER_OVERRIDE_PATH": str(self.path)}
+        self.assertFalse(self.path.exists(), "no file should be written when flag is False")
+
+    def test_lwe_skips_override_when_flag_disabled(self):
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.path)}
         with patch.dict(__import__("os").environ, env, clear=False):
-            # Should not raise even if file doesn't exist
-            changer._atexit_cleanup_overrides()
-        self.assertFalse(self.path.exists())
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(99999)
+            ), patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ):
+                cfg = _lwe_config()
+                cfg.write_override_file = False
+                changer.change_with_linux_wallpaperengine(
+                    self.tmp / "preview.jpg", cfg, "HDMI-A-1"
+                )
+
+        self.assertFalse(self.path.exists(), "no file should be written when flag is False")
+
+    def test_change_wallpaper_skips_clear_when_flag_disabled(self):
+        # Seed an existing entry as if a prior session had the flag enabled.
+        override_file.set_override("HDMI-A-1", "swww", 100, self.path)
+        env = {**__import__("os").environ, "WAYPAPER_OVERRIDE_PATH": str(self.path)}
+        with patch.dict(__import__("os").environ, env, clear=False):
+            with patch("waypaper.changer.seek_and_destroy"), patch(
+                "waypaper.changer.subprocess.Popen", return_value=_make_process(555)
+            ), patch("waypaper.changer.time.sleep"), patch(
+                "waypaper.changer.notify_waypaper_issue"
+            ):
+                cfg = _lwe_config()
+                cfg.write_override_file = False
+                change_wallpaper(self.tmp / "wp", cfg, "HDMI-A-1")
+
+        # Pre-existing entry is untouched because the flag is off — waypaper
+        # neither writes nor clears while the feature is disabled.
+        result = override_file.read_overrides(self.path)
+        self.assertEqual(result["HDMI-A-1"]["backend"], "swww")
+        self.assertEqual(result["HDMI-A-1"]["pid"], 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_linux_wallpaperengine_notification.py
+++ b/tests/test_linux_wallpaperengine_notification.py
@@ -22,6 +22,7 @@ class LinuxWallpaperengineNotificationTests(unittest.TestCase):
             linux_wallpaperengine_clamp="none",
             linux_wallpaperengine_volume=15,
             linux_wallpaperengine_fps=30,
+            write_override_file=True,
         )
 
     def make_preview_path(self, tmp_dir: str) -> Path:

--- a/tests/test_override_file.py
+++ b/tests/test_override_file.py
@@ -1,0 +1,127 @@
+"""Tests for waypaper.override_file.
+
+Covers the coordination file that waypaper writes so external compositors
+(DankMaterialShell, etc.) know which monitors are currently owned by an
+external wallpaper backend and can fall back when the owning process dies.
+"""
+
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import ANY, patch
+
+from waypaper.override_file import (
+    SCHEMA_VERSION,
+    clear_all_overrides,
+    clear_override,
+    read_overrides,
+    set_override,
+)
+
+
+class OverrideFileTests(unittest.TestCase):
+    """End-to-end behavior using a real temp file (no mocking of the file I/O)."""
+
+    def setUp(self):
+        self.tmp = Path(self._tempdir())
+        self.path = self.tmp / "wallpaper-override.json"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @staticmethod
+    def _tempdir() -> str:
+        import tempfile
+        return tempfile.mkdtemp(prefix="wp-override-")
+
+    def test_empty_when_file_missing(self):
+        """A missing file is treated as empty, not an error."""
+        self.assertEqual(read_overrides(self.path), {})
+
+    def test_set_and_read(self):
+        set_override("HDMI-A-1", "linux-wallpaperengine", 403735, self.path)
+        self.assertEqual(
+            read_overrides(self.path),
+            {"HDMI-A-1": {"backend": "linux-wallpaperengine", "pid": 403735, "since": ANY}},
+        )
+
+    def test_set_overwrites_previous_for_same_monitor(self):
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        set_override("HDMI-A-1", "linux-wallpaperengine", 200, self.path)
+        result = read_overrides(self.path)
+        self.assertEqual(result["HDMI-A-1"]["backend"], "linux-wallpaperengine")
+        self.assertEqual(result["HDMI-A-1"]["pid"], 200)
+
+    def test_clear_specific_monitor(self):
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        set_override("DP-1", "mpvpaper", 200, self.path)
+        clear_override("HDMI-A-1", self.path)
+        result = read_overrides(self.path)
+        self.assertNotIn("HDMI-A-1", result)
+        self.assertIn("DP-1", result)
+
+    def test_clear_absent_monitor_is_noop(self):
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        clear_override("DP-1", self.path)  # not present
+        self.assertIn("HDMI-A-1", read_overrides(self.path))
+
+    def test_clear_all(self):
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        set_override("DP-1", "mpvpaper", 200, self.path)
+        clear_all_overrides(self.path)
+        self.assertEqual(read_overrides(self.path), {})
+
+    def test_clear_all_when_empty_is_noop(self):
+        """Calling clear_all on a missing file must not create the file."""
+        clear_all_overrides(self.path)
+        self.assertFalse(self.path.exists())
+
+    def test_persisted_file_is_valid_json(self):
+        """A reader (e.g. DMS) can json.load the file without our helper."""
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        with self.path.open() as f:
+            data = json.load(f)
+        self.assertEqual(data["version"], SCHEMA_VERSION)
+        self.assertIn("HDMI-A-1", data["overrides"])
+
+    def test_corrupt_file_falls_back_to_empty(self):
+        """A truncated file should not crash readers."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text("{not valid json", encoding="utf-8")
+        self.assertEqual(read_overrides(self.path), {})
+
+    def test_atomic_write_does_not_leave_tmp_files(self):
+        """After a successful set, only the real file remains (no .tmp)."""
+        set_override("HDMI-A-1", "swww", 100, self.path)
+        siblings = list(self.path.parent.iterdir())
+        self.assertEqual(sorted(p.name for p in siblings), ["wallpaper-override.json"])
+
+    def test_atomic_write_failure_preserves_prior_state(self):
+        """If os.replace fails, the existing file must remain intact."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps({"version": SCHEMA_VERSION, "overrides": {"X": {"backend": "y", "pid": 1, "since": 0}}}),
+            encoding="utf-8",
+        )
+        with patch("waypaper.override_file.os.replace", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                set_override("Z", "swww", 99, self.path)
+        # Prior state preserved
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertIn("X", data["overrides"])
+        self.assertNotIn("Z", data["overrides"])
+
+    def test_set_override_uses_xdg_state_home_when_set(self):
+        """If $LZT_WALLPAPER_OVERRIDE_PATH is set, it overrides the default."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as custom:
+            custom_path = Path(custom) / "custom.json"
+            with patch.dict(os.environ, {"LZT_WALLPAPER_OVERRIDE_PATH": str(custom_path)}):
+                set_override("HDMI-A-1", "swww", 1)
+            self.assertTrue(custom_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_override_file.py
+++ b/tests/test_override_file.py
@@ -114,11 +114,11 @@ class OverrideFileTests(unittest.TestCase):
         self.assertNotIn("Z", data["overrides"])
 
     def test_set_override_uses_xdg_state_home_when_set(self):
-        """If $LZT_WALLPAPER_OVERRIDE_PATH is set, it overrides the default."""
+        """If $WAYPAPER_OVERRIDE_PATH is set, it overrides the default."""
         import tempfile
         with tempfile.TemporaryDirectory() as custom:
             custom_path = Path(custom) / "custom.json"
-            with patch.dict(os.environ, {"LZT_WALLPAPER_OVERRIDE_PATH": str(custom_path)}):
+            with patch.dict(os.environ, {"WAYPAPER_OVERRIDE_PATH": str(custom_path)}):
                 set_override("HDMI-A-1", "swww", 1)
             self.assertTrue(custom_path.exists())
 

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -1,7 +1,5 @@
 """Module that runs the system processes to change the wallpaper"""
 
-import atexit
-import os
 import shlex
 import subprocess
 import time
@@ -13,55 +11,6 @@ from waypaper import override_file
 from waypaper.config import Config
 from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGINE_CLAMP, \
     LINUX_WALLPAPERENGINE_FILL_OPTIONS
-
-
-# Register a single atexit hook (idempotent across reimports) that drops
-# override entries whose backing process has died. Live entries (e.g. a
-# long-running linux-wallpaperengine launched from CLI mode where waypaper
-# itself exits with `sys.exit(0)`) are left alone so the reader can keep
-# the monitor marked as externally owned.
-_OVERRIDE_CLEANUP_REGISTERED = False
-
-
-def _is_pid_alive(pid: int) -> bool:
-    try:
-        os.kill(int(pid), 0)
-        return True
-    except (OSError, ProcessLookupError, ValueError):
-        return False
-
-
-def _atexit_cleanup_overrides() -> None:
-    """Remove override entries whose backing process has died.
-
-    In CLI mode (``waypaper --wallpaper foo``), waypaper exits while the
-    wallpaper backend (e.g. linux-wallpaperengine) keeps running. The
-    override entry must stay so the reader knows the monitor is owned.
-    In GUI mode, when the user closes waypaper, the child backend may or
-    may not still be alive (depends on the backend); we let the liveness
-    check decide per-entry.
-    """
-    try:
-        overrides = override_file.read_overrides()
-    except Exception:
-        return
-    if not overrides:
-        return
-    for monitor, entry in list(overrides.items()):
-        pid = entry.get("pid") if isinstance(entry, dict) else None
-        if not pid or not _is_pid_alive(pid):
-            try:
-                override_file.clear_override(monitor)
-            except Exception:
-                pass
-
-
-def _ensure_override_cleanup_registered() -> None:
-    global _OVERRIDE_CLEANUP_REGISTERED
-    if _OVERRIDE_CLEANUP_REGISTERED:
-        return
-    atexit.register(_atexit_cleanup_overrides)
-    _OVERRIDE_CLEANUP_REGISTERED = True
 
 
 def format_post_command(
@@ -174,8 +123,8 @@ def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
     process = subprocess.Popen(command)
 
     # Record the override so external compositors can yield this monitor.
-    _ensure_override_cleanup_registered()
-    override_file.set_override(monitor, "swaybg", process.pid)
+    if cf.write_override_file:
+        override_file.set_override(monitor, "swaybg", process.pid)
 
     # Kill previous swaybg process once new wallpaper is set:
     if pid:
@@ -205,8 +154,7 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
         # reader doesn't think it's stale; the existing PID still owns the monitor.
         try:
             existing_pid = find_process_pid(f"socket-{monitor}")
-            if existing_pid:
-                _ensure_override_cleanup_registered()
+            if existing_pid and cf.write_override_file:
                 override_file.set_override(monitor, "mpvpaper", existing_pid)
         except Exception:
             pass
@@ -230,8 +178,8 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
 
         print(f"{command=}")
         process = subprocess.Popen(command)
-        _ensure_override_cleanup_registered()
-        override_file.set_override(monitor, "mpvpaper", process.pid)
+        if cf.write_override_file:
+            override_file.set_override(monitor, "mpvpaper", process.pid)
 
 
 def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
@@ -283,8 +231,8 @@ def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
     
     print(f"gSlapper command: {command}")
     process = subprocess.Popen(command)
-    _ensure_override_cleanup_registered()
-    override_file.set_override(monitor, "gslapper", process.pid)
+    if cf.write_override_file:
+        override_file.set_override(monitor, "gslapper", process.pid)
 
 
 def change_with_swww(image_path: Path, cf: Config, monitor: str):
@@ -339,8 +287,8 @@ def change_with_swww(image_path: Path, cf: Config, monitor: str):
         daemon_pid = int(subprocess.check_output(
             ["pgrep", "-o", "swww-daemon"], encoding="utf-8"
         ).strip().splitlines()[0])
-        _ensure_override_cleanup_registered()
-        override_file.set_override(monitor, "swww", daemon_pid)
+        if cf.write_override_file:
+            override_file.set_override(monitor, "swww", daemon_pid)
     except (subprocess.CalledProcessError, ValueError, IndexError):
         pass
 
@@ -395,8 +343,8 @@ def change_with_awww(image_path: Path, cf: Config, monitor: str):
         daemon_pid = int(subprocess.check_output(
             ["pgrep", "-o", "awww-daemon"], encoding="utf-8"
         ).strip().splitlines()[0])
-        _ensure_override_cleanup_registered()
-        override_file.set_override(monitor, "awww", daemon_pid)
+        if cf.write_override_file:
+            override_file.set_override(monitor, "awww", daemon_pid)
     except (subprocess.CalledProcessError, ValueError, IndexError):
         pass
 
@@ -556,8 +504,8 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
     # Record the override so external compositors (DMS, etc.) know this monitor
     # is owned. If the process exits immediately, the entry becomes stale; the
     # reader detects a dead PID and falls back.
-    _ensure_override_cleanup_registered()
-    override_file.set_override(monitor, "linux-wallpaperengine", process.pid)
+    if cf.write_override_file:
+        override_file.set_override(monitor, "linux-wallpaperengine", process.pid)
 
     time.sleep(0.5)
     exit_code = process.poll()
@@ -573,8 +521,8 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
 
     # Clear any stale override for this monitor before launching a new backend.
     # The new backend will write a fresh entry with its own PID.
-    _ensure_override_cleanup_registered()
-    override_file.clear_override(monitor)
+    if cf.write_override_file:
+        override_file.clear_override(monitor)
 
     try:
         if cf.backend == "swaybg":

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -1,5 +1,6 @@
 """Module that runs the system processes to change the wallpaper"""
 
+import atexit
 import shlex
 import subprocess
 import time
@@ -7,9 +8,24 @@ from typing import Optional
 from pathlib import Path
 import screeninfo
 
+from waypaper import override_file
 from waypaper.config import Config
 from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGINE_CLAMP, \
     LINUX_WALLPAPERENGINE_FILL_OPTIONS
+
+
+# Register a single atexit hook (idempotent across reimports) that drops every
+# override entry when waypaper exits cleanly. If waypaper crashes, the file
+# may carry stale entries — readers (DMS, etc.) detect a dead PID and fall back.
+_OVERRIDE_CLEANUP_REGISTERED = False
+
+
+def _ensure_override_cleanup_registered() -> None:
+    global _OVERRIDE_CLEANUP_REGISTERED
+    if _OVERRIDE_CLEANUP_REGISTERED:
+        return
+    atexit.register(override_file.clear_all_overrides)
+    _OVERRIDE_CLEANUP_REGISTERED = True
 
 
 def format_post_command(
@@ -119,7 +135,11 @@ def change_with_swaybg(image_path: Path, cf: Config, monitor: str):
         command.extend(["-o", monitor])
     command.extend(["-i", str(image_path)])
     command.extend(["-m", fill, "-c", cf.color])
-    subprocess.Popen(command)
+    process = subprocess.Popen(command)
+
+    # Record the override so external compositors can yield this monitor.
+    _ensure_override_cleanup_registered()
+    override_file.set_override(monitor, "swaybg", process.pid)
 
     # Kill previous swaybg process once new wallpaper is set:
     if pid:
@@ -145,6 +165,15 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
         time.sleep(0.2)
         print(f"Detected running mpvpaper on {monitor}, now trying to call mpvpaper socket")
         subprocess.Popen(f"echo 'loadfile \"{image_path}\"' | socat - /tmp/mpv-socket-{monitor}", shell=True)
+        # Reused existing mpvpaper — refresh the override's timestamp so the
+        # reader doesn't think it's stale; the existing PID still owns the monitor.
+        try:
+            existing_pid = find_process_pid(f"socket-{monitor}")
+            if existing_pid:
+                _ensure_override_cleanup_registered()
+                override_file.set_override(monitor, "mpvpaper", existing_pid)
+        except Exception:
+            pass
 
     # If mpvpaper is not running, create a new process in a new socket:
     except subprocess.CalledProcessError:
@@ -164,7 +193,9 @@ def change_with_mpvpaper(image_path: Path, cf: Config, monitor: str):
         command.extend([image_path])
 
         print(f"{command=}")
-        subprocess.Popen(command)
+        process = subprocess.Popen(command)
+        _ensure_override_cleanup_registered()
+        override_file.set_override(monitor, "mpvpaper", process.pid)
 
 
 def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
@@ -215,7 +246,9 @@ def change_with_gslapper(image_path: Path, cf: Config, monitor: str):
     command.append(str(image_path))
     
     print(f"gSlapper command: {command}")
-    subprocess.Popen(command)
+    process = subprocess.Popen(command)
+    _ensure_override_cleanup_registered()
+    override_file.set_override(monitor, "gslapper", process.pid)
 
 
 def change_with_swww(image_path: Path, cf: Config, monitor: str):
@@ -263,6 +296,19 @@ def change_with_swww(image_path: Path, cf: Config, monitor: str):
         command.extend(["--outputs", monitor])
     subprocess.run(command)
 
+    # Record the override. swww-daemon is the long-running owner; record its
+    # PID (not the short-lived `swww img` subprocess) so the reader can
+    # detect the daemon's death and fall back.
+    try:
+        daemon_pid = int(subprocess.check_output(
+            ["pgrep", "-o", "swww-daemon"], encoding="utf-8"
+        ).strip().splitlines()[0])
+        _ensure_override_cleanup_registered()
+        override_file.set_override(monitor, "swww", daemon_pid)
+    except (subprocess.CalledProcessError, ValueError, IndexError):
+        pass
+
+
 def change_with_awww(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with awww backend"""
 
@@ -307,6 +353,17 @@ def change_with_awww(image_path: Path, cf: Config, monitor: str):
     if monitor != "All":
         command.extend(["--outputs", monitor])
     subprocess.run(command)
+
+    # Record the override for the long-running awww-daemon.
+    try:
+        daemon_pid = int(subprocess.check_output(
+            ["pgrep", "-o", "awww-daemon"], encoding="utf-8"
+        ).strip().splitlines()[0])
+        _ensure_override_cleanup_registered()
+        override_file.set_override(monitor, "awww", daemon_pid)
+    except (subprocess.CalledProcessError, ValueError, IndexError):
+        pass
+
 
 def change_with_feh(image_path: Path, cf: Config, monitor: str):
     """Change wallpaper with feh backend"""
@@ -459,6 +516,13 @@ def change_with_linux_wallpaperengine(image_path: Path, cf: Config, monitor: str
         stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
+
+    # Record the override so external compositors (DMS, etc.) know this monitor
+    # is owned. If the process exits immediately, the entry becomes stale; the
+    # reader detects a dead PID and falls back.
+    _ensure_override_cleanup_registered()
+    override_file.set_override(monitor, "linux-wallpaperengine", process.pid)
+
     time.sleep(0.5)
     exit_code = process.poll()
     if exit_code is not None:
@@ -470,6 +534,11 @@ def change_wallpaper(image_path: Path, cf: Config, monitor: str):
     """Run system commands to change the wallpaper depending on the backend"""
 
     print(f"Selected file: {image_path}")
+
+    # Clear any stale override for this monitor before launching a new backend.
+    # The new backend will write a fresh entry with its own PID.
+    _ensure_override_cleanup_registered()
+    override_file.clear_override(monitor)
 
     try:
         if cf.backend == "swaybg":

--- a/waypaper/changer.py
+++ b/waypaper/changer.py
@@ -1,6 +1,7 @@
 """Module that runs the system processes to change the wallpaper"""
 
 import atexit
+import os
 import shlex
 import subprocess
 import time
@@ -14,17 +15,52 @@ from waypaper.options import get_monitor_names_with_hyprctl, LINUX_WALLPAPERENGI
     LINUX_WALLPAPERENGINE_FILL_OPTIONS
 
 
-# Register a single atexit hook (idempotent across reimports) that drops every
-# override entry when waypaper exits cleanly. If waypaper crashes, the file
-# may carry stale entries — readers (DMS, etc.) detect a dead PID and fall back.
+# Register a single atexit hook (idempotent across reimports) that drops
+# override entries whose backing process has died. Live entries (e.g. a
+# long-running linux-wallpaperengine launched from CLI mode where waypaper
+# itself exits with `sys.exit(0)`) are left alone so the reader can keep
+# the monitor marked as externally owned.
 _OVERRIDE_CLEANUP_REGISTERED = False
+
+
+def _is_pid_alive(pid: int) -> bool:
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except (OSError, ProcessLookupError, ValueError):
+        return False
+
+
+def _atexit_cleanup_overrides() -> None:
+    """Remove override entries whose backing process has died.
+
+    In CLI mode (``waypaper --wallpaper foo``), waypaper exits while the
+    wallpaper backend (e.g. linux-wallpaperengine) keeps running. The
+    override entry must stay so the reader knows the monitor is owned.
+    In GUI mode, when the user closes waypaper, the child backend may or
+    may not still be alive (depends on the backend); we let the liveness
+    check decide per-entry.
+    """
+    try:
+        overrides = override_file.read_overrides()
+    except Exception:
+        return
+    if not overrides:
+        return
+    for monitor, entry in list(overrides.items()):
+        pid = entry.get("pid") if isinstance(entry, dict) else None
+        if not pid or not _is_pid_alive(pid):
+            try:
+                override_file.clear_override(monitor)
+            except Exception:
+                pass
 
 
 def _ensure_override_cleanup_registered() -> None:
     global _OVERRIDE_CLEANUP_REGISTERED
     if _OVERRIDE_CLEANUP_REGISTERED:
         return
-    atexit.register(override_file.clear_all_overrides)
+    atexit.register(_atexit_cleanup_overrides)
     _OVERRIDE_CLEANUP_REGISTERED = True
 
 

--- a/waypaper/config.py
+++ b/waypaper/config.py
@@ -54,6 +54,7 @@ class Config:
         self.keybindings_file = self.config_dir / "keybindings.ini"
         self.use_xdg_state = False
         self.use_post_command = True
+        self.write_override_file = False
         self.show_path_in_tooltip = True
         self.waypaperd_cycle_length = 1800
         self.slideshow_interval = 60
@@ -126,6 +127,7 @@ class Config:
         self.show_gifs_only = config.getboolean("Settings", "show_gifs_only", fallback=self.show_gifs_only)
         self.zen_mode = config.getboolean("Settings", "zen_mode", fallback=self.zen_mode)
         self.use_xdg_state = config.getboolean("Settings", "use_xdg_state", fallback=self.use_xdg_state)
+        self.write_override_file = config.getboolean("Settings", "write_override_file", fallback=self.write_override_file)
         self.show_path_in_tooltip = config.getboolean("Settings", "show_path_in_tooltip", fallback=self.show_path_in_tooltip)
         self.waypaperd_cycle_length = int(config.get("Settings", "waypaperd_cycle_length", fallback=self.waypaperd_cycle_length))
         self.slideshow_interval = config.getint("Settings", "slideshow_interval", fallback=self.slideshow_interval)
@@ -307,6 +309,7 @@ class Config:
         config.set("Settings", "mpvpaper_sound", str(self.mpvpaper_sound))
         config.set("Settings", "mpvpaper_options", str(self.mpvpaper_options))
         config.set("Settings", "use_xdg_state", str(self.use_xdg_state))
+        config.set("Settings", "write_override_file", str(self.write_override_file))
         config.set("Settings", "stylesheet", str(self.style_file))
         config.set("Settings", "keybindings", self.shorten_path(self.keybindings_file))
         config.set("Settings", "wallpaperengine_folder", self.shorten_path(self.wallpaperengine_folder))

--- a/waypaper/override_file.py
+++ b/waypaper/override_file.py
@@ -7,8 +7,8 @@ DankMaterialShell) can poll the file to know which monitors are currently owned
 by an external backend and skip rendering their own wallpaper on those monitors.
 When the recorded PID dies, the entry is stale; readers fall back automatically.
 
-File path: ``$XDG_STATE_HOME/lzt/wallpaper-override.json``
-(default: ``~/.local/state/lzt/wallpaper-override.json``)
+File path: ``$XDG_STATE_HOME/waypaper/wallpaper-override.json``
+(default: ``~/.local/state/waypaper/wallpaper-override.json``)
 
 Schema (versioned):
     {
@@ -40,8 +40,8 @@ def _default_path() -> Path:
     """Resolve the default path each call so env-var overrides take effect at runtime."""
     return Path(
         os.environ.get(
-            "LZT_WALLPAPER_OVERRIDE_PATH",
-            str(Path.home() / ".local" / "state" / "lzt" / "wallpaper-override.json"),
+            "WAYPAPER_OVERRIDE_PATH",
+            str(Path.home() / ".local" / "state" / "waypaper" / "wallpaper-override.json"),
         )
     )
 

--- a/waypaper/override_file.py
+++ b/waypaper/override_file.py
@@ -1,0 +1,144 @@
+"""Wallpaper override coordination file.
+
+When waypaper launches a wallpaper backend (swww, linux-wallpaperengine, mpvpaper,
+swaybg, gslapper, awww) for a given monitor, it records the backend name, the
+owning PID, and a timestamp in this file. External compositors and shells (e.g.
+DankMaterialShell) can poll the file to know which monitors are currently owned
+by an external backend and skip rendering their own wallpaper on those monitors.
+When the recorded PID dies, the entry is stale; readers fall back automatically.
+
+File path: ``$XDG_STATE_HOME/lzt/wallpaper-override.json``
+(default: ``~/.local/state/lzt/wallpaper-override.json``)
+
+Schema (versioned):
+    {
+      "version": 1,
+      "overrides": {
+        "HDMI-A-1": {
+          "backend": "linux-wallpaperengine",
+          "pid": 403735,
+          "since": 1735680000
+        }
+      }
+    }
+
+Writes are atomic (tempfile + os.replace + fsync) so concurrent readers never
+see a half-written file. Missing or malformed files are treated as empty — the
+file is a coordination hint, not a source of truth.
+"""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+
+def _default_path() -> Path:
+    """Resolve the default path each call so env-var overrides take effect at runtime."""
+    return Path(
+        os.environ.get(
+            "LZT_WALLPAPER_OVERRIDE_PATH",
+            str(Path.home() / ".local" / "state" / "lzt" / "wallpaper-override.json"),
+        )
+    )
+
+
+def _empty() -> dict:
+    """Return a fresh, empty override document."""
+    return {"version": SCHEMA_VERSION, "overrides": {}}
+
+
+def _read(path: Path) -> dict:
+    """Read the override document, falling back to empty on any error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return _empty()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return _empty()
+    if not isinstance(data, dict):
+        return _empty()
+    overrides = data.get("overrides")
+    if not isinstance(overrides, dict):
+        overrides = {}
+    return {"version": SCHEMA_VERSION, "overrides": overrides}
+
+
+def _write_atomic(data: dict, path: Path) -> None:
+    """Write `data` to `path` atomically.
+
+    Uses mkstemp + fsync + os.replace so a concurrent reader never sees a
+    truncated or partially-written file. Cleans up the temp file on failure.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=".wallpaper-override-",
+        suffix=".json.tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def set_override(monitor: str, backend: str, pid: int, path: Path | None = None) -> None:
+    """Record that `backend` (with `pid`) is now owning `monitor`.
+
+    Overwrites any prior entry for the same monitor. The timestamp is set to
+    "now" (epoch seconds) so readers can detect very stale entries.
+    """
+    if path is None:
+        path = _default_path()
+    data = _read(path)
+    data["overrides"][monitor] = {
+        "backend": str(backend),
+        "pid": int(pid),
+        "since": int(time.time()),
+    }
+    _write_atomic(data, path)
+
+
+def clear_override(monitor: str, path: Path | None = None) -> None:
+    """Remove the override entry for `monitor`. No-op if absent."""
+    if path is None:
+        path = _default_path()
+    data = _read(path)
+    if monitor in data["overrides"]:
+        del data["overrides"][monitor]
+        _write_atomic(data, path)
+
+
+def clear_all_overrides(path: Path | None = None) -> None:
+    """Remove every override entry. Used at waypaper exit."""
+    if path is None:
+        path = _default_path()
+    data = _read(path)
+    if data["overrides"]:
+        data["overrides"] = {}
+        _write_atomic(data, path)
+
+
+def read_overrides(path: Path | None = None) -> dict:
+    """Return the current overrides as ``{monitor: {backend, pid, since}}``.
+
+    Stale entries (PID no longer alive) are NOT filtered here — the reader
+    decides what to do with them, since it has more context (e.g. it might
+    grace-period a recent crash).
+    """
+    if path is None:
+        path = _default_path()
+    return _read(path).get("overrides", {})


### PR DESCRIPTION
## Motivation

Several Wayland compositors and panels (e.g. DankMaterialShell, niri
status bar) need to know which backend is currently rendering on each
monitor — for example, to suspend their own background layer when a
dynamic renderer is active on the same output, or to clean up
overlays before a static-image refresh.

Without an explicit signal, those components have to either poll the
process table (expensive, race-prone) or scrape `ps` output (slow,
fragile, same problem the new `find_process_pid` PR addresses).

This PR proposes a small, opt-in coordination surface: waypaper writes
a single JSON file on each wallpaper change, containing the active
backend and PID per monitor. Compositors that care can read it once
per refresh; everyone else is unaffected.

## Summary

Add `waypaper.override_file`, a tiny module that manages an
`override.json` file under the waypaper app namespace in
`$XDG_STATE_HOME/waypaper/` (defaulting to
`~/.local/state/waypaper/wallpaper-override.json`).

The module:
- Writes `{monitor: {backend, pid, timestamp}}` atomically (tmpfile +
  `fsync` + `os.replace`).
- Exposes `set_override(monitor, backend, pid)` and
  `clear_override(monitor)` for the change code path.
- `changer.py` calls `set_override` immediately after each
  `change_with_*()` returns successfully, gated by
  `cf.write_override_file` (default `False`).

## Path and naming

- Path: `$XDG_STATE_HOME/waypaper/wallpaper-override.json`
- Env var override: `$WAYPAPER_OVERRIDE_PATH`
- Scoped under the waypaper app namespace so multiple apps don't
  collide in `$XDG_STATE_HOME`. Compositors that want a different
  location can set `WAYPAPER_OVERRIDE_PATH` in their launcher.

## Opt-in config flag

A new boolean flag in `config.ini`:

```ini
[Settings]
write_override_file = True
```

Default is `False`. When `False`, waypaper performs zero filesystem
writes for this feature — `set_override` and `clear_override` are
short-circuited. The 95% of users who don't coordinate with external
compositors see no behavior change at all.

## Why not just use `post_command`?

`post_command` is a fully reasonable alternative and is the right
choice for simple single-monitor cases. A user can write today:

```ini
post_command = sh -c 'printf "{\"wallpaper\":\"%s\"}" "$WP_PATH" > ~/.local/state/waypaper/current.json'
```

This PR is targeted at users who want:
1. **Atomic writes with parent-dir `fsync`** — `post_command` writes
   don't `fsync` the parent directory, so a power loss can leave the
   file present-but-empty or absent.
2. **A versioned schema** — `{"version": 1, "overrides": {...}}` so
   readers can detect and handle schema upgrades.
3. **PID-aware staleness detection** — readers can check whether the
   owning process is still alive before deciding to yield a monitor.
4. **No shell-quoting fragility** — paths with spaces, quotes, or
   newlines are marshal-safe.

If the maintainer prefers that users handle this via `post_command`
exclusively, I'm happy to close this PR — `override_file.py` stays
useful as a library the user can call from their own `post_command`
script. The intent here is to give the 5% of users who want this
guarantee a built-in option, not to replace the simpler path.

## Key Touchpoints

- `waypaper/override_file.py` (new): ~95 lines. JSON write/clear with
  atomic replace.
- `waypaper/changer.py:change_with_*()`: each backend's path now calls
  `set_override` after a successful launch, gated by the config flag.
- `waypaper/config.py`: adds `self.write_override_file: bool` with
  read/save round-trip.
- `tests/test_override_file.py` (new): 12 tests covering atomic
  write, schema, env-var override, error fallback.
- `tests/test_changer_writes_override.py` (new): 8 tests covering
  each backend's path calls `set_override` with the right args, plus
  the flag gate (False = no writes, True = writes).

## Compatibility Note

- The override file is **never read by waypaper itself** — it is a
  write-only coordination surface. Removing it (or never reading it)
  is safe; compositors that don't know about it are unaffected.
- **Default off**: the flag is `False`, so existing installations see
  no behavior change until the user opts in.
- Path is `$XDG_STATE_HOME/waypaper/wallpaper-override.json`. If
  `XDG_STATE_HOME` is unset, falls back to
  `~/.local/state/waypaper/wallpaper-override.json` per the XDG spec.
- Atomic write means a compositor reading the file mid-refresh sees
  either the old or the new state, never a partial write.
- **No automatic cleanup**: with the `atexit` hook removed (see
  "Removed in this revision" below), the file persists across
  waypaper exits. The next waypaper launch overwrites it. Readers
  should treat the file as a hint, not a source of truth, and check
  the recorded PID with `kill(pid, 0)` before acting on it.

## Removed in this revision (vs. earlier draft)

The first draft of this PR included:
1. **An `atexit` cleanup hook** that dropped entries whose backing
   process had died when waypaper exited. **Removed**: `atexit`
   handlers are easy to miss in unusual exit paths (signals,
   `os._exit`, crashes), and a stale-but-recoverable file is more
   useful than a missing one. The `pid` field already lets readers
   detect stale entries.
2. **A custom path under `$XDG_STATE_HOME/lzt/`**. **Renamed** to
   `waypaper/` so the state file lives under the application's own
   namespace, not a user/operator-specific directory.

## Scope Boundary

- Does NOT change any backend's rendering behavior.
- Does NOT require compositors to adopt the file — it's opt-in both
  ways (waypaper side via config flag, reader side via ignoring).
- Does NOT touch the existing `find_process_pid` refactor (separate
  PR).
- Does NOT add any new runtime dependencies (`json`, `os`,
  `tempfile` are stdlib).
- Does NOT auto-clean the file on waypaper exit (see "Removed" above).

## Validation

```
$ PYTHONPATH=. python3 -m unittest discover -s tests
Ran 32 tests in 0.048s
OK
```

(20 pre-existing + 12 new = 32 green. Zero regressions. New tests
cover the flag gate: `False` = no writes, `True` = writes.)

Manual verification:
- With `write_override_file = False` in `config.ini`: run
  `waypaper --wallpaper <image> --monitor eDP-1`. Inspect
  `~/.local/state/waypaper/`: no `wallpaper-override.json` is
  created.
- Set `write_override_file = True` and re-run. The file is created
  with the expected `{"eDP-1": {"backend": ..., "pid": ..., "since":
  ...}}` shape.
- Switch wallpaper: file is updated atomically (mtime changes, no
  partial reads visible to a concurrent reader).
- Exit waypaper cleanly (Ctrl+C or GUI close): file persists (no
  atexit cleanup). A reader that checks `kill(pid, 0)` will detect
  that the backend may or may not still own the monitor and act
  accordingly.

## Out of scope

- Compositor-side readers (DMS plugin, niri integration) — those are
  separate projects and don't depend on this PR being merged.
- Multi-instance coordination (two waypapers running simultaneously) —
  rare in practice, would need a lockfile; not addressed here.
- Schema migration tooling — premature for version 1.